### PR TITLE
Save conversation logs to JSONL

### DIFF
--- a/jsonl.py
+++ b/jsonl.py
@@ -1,5 +1,8 @@
 import streamlit as st
 import json
+from pathlib import Path
+
+DATASET_PATH = Path(__file__).parent / "json" / "dataset.jsonl"
 
 def save_jsonl_entry(label: str):
     """会話ログをjsonl形式で1行保存"""
@@ -22,6 +25,10 @@ def save_jsonl_entry(label: str):
     if "saved_jsonl" not in st.session_state:
         st.session_state.saved_jsonl = []
     st.session_state.saved_jsonl.append(entry)
+
+    DATASET_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with DATASET_PATH.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
 def show_jsonl_block():
     """保存済みjsonlデータをコードブロックで表示"""


### PR DESCRIPTION
## Summary
- persist conversation entries to `json/dataset.jsonl` when saving

## Testing
- `python -m py_compile jsonl.py streamlit_app.py`
- `python - <<'PY'
import os, json
import streamlit as st
import jsonl

st.session_state.context=[{"role":"user","content":"指示"},{"role":"assistant","content":"質問1"},{"role":"user","content":"答え1"}]
jsonl.save_jsonl_entry('sufficient')
print('saved', os.path.exists(jsonl.DATASET_PATH))
with open(jsonl.DATASET_PATH, 'r', encoding='utf-8') as f:
    print('file content:', f.read())
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b41880d1848320b32c7e9f218d07a4