### PR TITLE
feat: log conversation updates

### DIFF
--- a/jsonl.py
+++ b/jsonl.py
@@ -27,7 +27,14 @@ def save_jsonl_entry(label: str):
     st.session_state.saved_jsonl.append(entry)
 
     DATASET_PATH.parent.mkdir(parents=True, exist_ok=True)
+    need_newline = False
+    if DATASET_PATH.exists() and DATASET_PATH.stat().st_size > 0:
+        with DATASET_PATH.open("rb") as f:
+            f.seek(-1, 2)
+            need_newline = f.read(1) != b"\n"
     with DATASET_PATH.open("a", encoding="utf-8") as f:
+        if need_newline:
+            f.write("\n")
         f.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
 def show_jsonl_block():

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -128,6 +128,7 @@ def app():
             # 3) アシスタント応答からも部屋名を検出 → 新規なら画像添付（次の推論に活かす）
             rooms_from_assistant = detect_rooms_in_text(reply)
             attach_images_for_rooms(rooms_from_assistant)
+            save_jsonl_entry("insufficient")
 
 
     # 3) 追加の自由入力（会話継続用）
@@ -142,6 +143,7 @@ def app():
         print("Assistant:", reply)
         context.append({"role": "assistant", "content": reply})
         print("context: ", context)
+        save_jsonl_entry("insufficient")
 
     # 4) 画面下部に履歴を全表示（systemは省く）
     last_assistant_idx = max((i for i, m in enumerate(context) if m["role"] == "assistant"), default=None)
@@ -177,6 +179,7 @@ def app():
                     context.append({"role": "assistant", "content": question})
                     rooms_from_assistant = detect_rooms_in_text(question)
                     attach_images_for_rooms(rooms_from_assistant)
+                    save_jsonl_entry("insufficient")
                     st.rerun()
 
             if st.session_state.active == False:


### PR DESCRIPTION
## Summary
- ensure JSONL log appends on a new line
- save conversation state with label `insufficient` after each update

## Testing
- `python -m py_compile jsonl.py streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b42271c4f0832098ae98f9f66db52a