### PR TITLE
feat: choose house for image loading

### DIFF
--- a/move_functions.py
+++ b/move_functions.py
@@ -22,7 +22,11 @@ def detect_object(obj):
 
 def _room_to_path(room_name: str) -> str:
     fname = f"{room_name.lower()}.png"  # "KITCHEN" -> "kitchen.png"
-    return os.path.join(DEFAULT_IMAGE_DIR, fname)
+    image_dir = DEFAULT_IMAGE_DIR
+    house = st.session_state.get("selected_house")
+    if house:
+        image_dir = os.path.join(image_dir, house)
+    return os.path.join(image_dir, fname)
 
 def show_room_image(room_name: str) -> str:
     """

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -52,6 +52,15 @@ def attach_images_for_rooms(rooms: set[str], show_in_ui: bool = True):
 def app():
     st.title("LLMATCHデモアプリ")
 
+    image_root = "images"
+    house_dirs = [d for d in os.listdir(image_root) if os.path.isdir(os.path.join(image_root, d))]
+    default_label = "(default)"
+    options = [default_label] + house_dirs
+    current_house = st.session_state.get("selected_house", "")
+    current_label = current_house if current_house else default_label
+    selected_label = st.selectbox("想定する家", options, index=options.index(current_label) if current_label in options else 0)
+    st.session_state["selected_house"] = "" if selected_label == default_label else selected_label
+
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if "context" not in st.session_state:
         st.session_state["context"] = [


### PR DESCRIPTION
## Summary
- add top-level house selection in app to choose which home's images to use
- resolve room image paths based on selected house

## Testing
- `python -m py_compile streamlit_app.py move_functions.py`


------
https://chatgpt.com/codex/tasks/task_e_68b424c0171c8320a260841a11e23be6