### PR TITLE
Refactor room image path generation

### DIFF
--- a/move_functions.py
+++ b/move_functions.py
@@ -29,7 +29,7 @@ def show_room_image(room_name: str) -> str:
     Plan 実行時に呼ばれる表示関数。
     ローカルにある部屋画像（例: images/kitchen.png）を表示する。
     """
-    path = _room_to_path(room_name)
+    path = get_room_image_path(room_name)
     if os.path.exists(path):
         st.image(path, caption=f"{room_name} (local)")
         return f"Displayed local image for {room_name}: {path}"
@@ -37,6 +37,11 @@ def show_room_image(room_name: str) -> str:
         # ローカルに無い場合は控えめにメッセージ（必要なら公開URLのフォールバック実装も可能）
         st.warning(f"画像が見つかりません: {path}")
         return f"No local image found for {room_name}"
-    
+
 def get_room_image_path(room_name: str) -> str:
+    house = st.session_state.get("selected_house")
+    if house:
+        candidate = os.path.join(DEFAULT_IMAGE_DIR, house, f"{room_name.lower()}.png")
+        if os.path.exists(candidate):
+            return candidate
     return _room_to_path(room_name)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -52,6 +52,15 @@ def attach_images_for_rooms(rooms: set[str], show_in_ui: bool = True):
 def app():
     st.title("LLMATCHデモアプリ")
 
+    image_root = "images"
+    house_dirs = [d for d in os.listdir(image_root) if os.path.isdir(os.path.join(image_root, d))]
+    default_label = "(default)"
+    options = [default_label] + house_dirs
+    current_house = st.session_state.get("selected_house", "")
+    current_label = current_house if current_house else default_label
+    selected_label = st.selectbox("想定する家", options, index=options.index(current_label) if current_label in options else 0)
+    st.session_state["selected_house"] = "" if selected_label == default_label else selected_label
+
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if "context" not in st.session_state:
         st.session_state["context"] = [


### PR DESCRIPTION
## Summary
- keep `_room_to_path` independent of selected house
- resolve house-specific images in `get_room_image_path` and reuse in `show_room_image`

## Testing
- `python -m py_compile streamlit_app.py move_functions.py`


------
https://chatgpt.com/codex/tasks/task_e_68b424c0171c8320a260841a11e23be6