### PR TITLE
Add system prompt selector to chat pages

### DIFF
--- a/pages/gpt_with_critic.py
+++ b/pages/gpt_with_critic.py
@@ -6,7 +6,12 @@ import joblib
 from move_functions import move_to, pick_object, place_object_next_to, place_object_on, show_room_image, get_room_image_path
 from openai import OpenAI
 from dotenv import load_dotenv
-from api import client, SYSTEM_PROMPT
+from api import (
+    client,
+    SYSTEM_PROMPT_STANDARD,
+    SYSTEM_PROMPT_FRIENDLY,
+    SYSTEM_PROMPT_PRATFALL,
+)
 from two_classify import prepare_data  # 既存関数を利用
 
 load_dotenv()
@@ -82,6 +87,14 @@ def app():
     st.subheader("ChatGPT with 'Critic'")
     st.warning("このページは、再読み込み時にモデルの学習が行われるため、起動に時間がかかります。")
 
+    prompt_options = {
+        "Standard": SYSTEM_PROMPT_STANDARD,
+        "Friendly": SYSTEM_PROMPT_FRIENDLY,
+        "Pratfall": SYSTEM_PROMPT_PRATFALL,
+    }
+    prompt_label = st.selectbox("プロンプト", list(prompt_options.keys()))
+    system_prompt = prompt_options[prompt_label]
+
     image_root = "images"
     house_dirs = [d for d in os.listdir(image_root) if os.path.isdir(os.path.join(image_root, d))]
     default_label = "(default)"
@@ -92,16 +105,19 @@ def app():
     st.session_state["selected_house"] = "" if selected_label == default_label else selected_label
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
-    if "context" not in st.session_state:
-        st.session_state["context"] = [{"role": "system", "content": SYSTEM_PROMPT}]
-    if "active" not in st.session_state:
-        st.session_state.active = True
-    if "conv_log" not in st.session_state:
+    if (
+        "context" not in st.session_state
+        or st.session_state.get("system_prompt") != system_prompt
+    ):
+        st.session_state["context"] = [{"role": "system", "content": system_prompt}]
+        st.session_state["system_prompt"] = system_prompt
         st.session_state.conv_log = {
             "final_answer": "",
             "label": "",
             "clarifying_steps": []
         }
+    if "active" not in st.session_state:
+        st.session_state.active = True
 
     context = st.session_state["context"]
 


### PR DESCRIPTION
## Summary
- allow switching between standard, friendly, and pratfall system prompts
- reset conversation context when prompt changes for both modes

## Testing
- `python -m py_compile pages/gpt_only.py pages/gpt_with_critic.py`


------
https://chatgpt.com/codex/tasks/task_e_68b43b4a9c708320997b8962d288c52f