### PR TITLE
Attach room images when rooms are mentioned

### DIFF
--- a/pages/gpt_only.py
+++ b/pages/gpt_only.py
@@ -13,6 +13,7 @@ from api import (
 )
 from strips import strip_tags, extract_between
 from run_and_show import show_provisional_output, run_plan_and_show
+from room_utils import detect_rooms_in_text, attach_images_for_rooms
 
 load_dotenv()
 
@@ -73,6 +74,8 @@ def app():
         }
     if "active" not in st.session_state:
         st.session_state.active = True
+    if "sent_room_images" not in st.session_state:
+        st.session_state.sent_room_images = set()
 
     context = st.session_state["context"]
 
@@ -82,6 +85,8 @@ def app():
     
     if user_input:
         context.append({"role": "user", "content": user_input})
+        rooms_from_user = detect_rooms_in_text(user_input)
+        attach_images_for_rooms(rooms_from_user)
         response = client.chat.completions.create(
             model="gpt-4o-mini",
             messages=context
@@ -89,6 +94,8 @@ def app():
         reply = response.choices[0].message.content.strip()
         print("Assistant:", reply)
         context.append({"role": "assistant", "content": reply})
+        rooms_from_assistant = detect_rooms_in_text(reply)
+        attach_images_for_rooms(rooms_from_assistant)
         print("context: ", context)
 
     last_assistant_idx = max((i for i, m in enumerate(context) if m["role"] == "assistant"), default=None)

--- a/room_utils.py
+++ b/room_utils.py
@@ -1,0 +1,45 @@
+import os
+from typing import Set
+import streamlit as st
+from api import build_bootstrap_user_message
+from move_functions import show_room_image, get_room_image_path
+
+ROOM_TOKENS = ["BEDROOM", "KITCHEN", "DINING", "LIVING", "BATHROOM", "和室", "HALL", "LDK"]
+
+def detect_rooms_in_text(text: str) -> Set[str]:
+    """Return a set of room tokens found in text."""
+    found: Set[str] = set()
+    up = (text or "").upper()
+    for r in ROOM_TOKENS:
+        if r == "和室":
+            if "和室" in (text or ""):
+                found.add(r)
+        else:
+            if r in up:
+                found.add(r)
+    return found
+
+def attach_images_for_rooms(rooms: Set[str], show_in_ui: bool = True) -> None:
+    """Attach room images for new rooms to the conversation context and optionally display them."""
+    if "sent_room_images" not in st.session_state:
+        st.session_state.sent_room_images = set()
+    new_rooms = [r for r in rooms if r not in st.session_state.sent_room_images]
+    if not new_rooms:
+        return
+    local_paths = []
+    for room in new_rooms:
+        img_path = get_room_image_path(room)
+        if os.path.exists(img_path):
+            if show_in_ui:
+                show_room_image(room)
+            local_paths.append(img_path)
+            st.session_state.sent_room_images.add(room)
+        else:
+            st.warning(f"{room} の画像が見つかりません: {img_path}")
+    if local_paths:
+        st.session_state["context"].append(
+            build_bootstrap_user_message(
+                text=f"Here are room images for: {', '.join(new_rooms)}. Use them for scene understanding and disambiguation.",
+                local_image_paths=local_paths,
+            )
+        )


### PR DESCRIPTION
## Summary
- Add reusable utilities to detect room names and attach matching images to the conversation context
- Update Streamlit apps to show detected room images in the UI and include them in the prompt for subsequent requests

## Testing
- `python -m py_compile streamlit_app.py pages/gpt_only.py pages/gpt_with_critic.py room_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68b44a97e3e8832089d1ce5faef7b3ae