### PR TITLE
Persist information across turns

### DIFF
--- a/run_and_show.py
+++ b/run_and_show.py
@@ -22,6 +22,15 @@ def show_clarifying_question(reply: str):
     st.write(q_match.group(1).strip())
 
 
+def show_information(reply: str):
+    """<Information> ... </Information> の内容を箇条書きで表示"""
+    info_match = re.search(r"<Information>([\s\S]*?)</Information>", reply, re.IGNORECASE)
+    if not info_match:
+        return
+    st.subheader("Information")
+    st.markdown("<ul>" + info_match.group(1).strip() + "</ul>", unsafe_allow_html=True)
+
+
 def show_provisional_output(reply: str):
     """<ProvisionalOutput> 内の関数列と確認質問のみを表示"""
     prov_match = re.search(


### PR DESCRIPTION
## Summary
- Accumulate `<Information>` bullet items across conversation turns
- Display aggregated information via new `show_information` helper

## Testing
- `python -m py_compile run_and_show.py streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6c445b3f88320bfa0df217e429a7f