### PR TITLE
Normalize move_to tag format

### DIFF
--- a/strips.py
+++ b/strips.py
@@ -3,6 +3,18 @@ import re
 
 TAG_RE = re.compile(r"</?([A-Za-z0-9_]+)(\s[^>]*)?>")
 
+ROOM_TRANSLATIONS = {
+    "BATHROOM": "洗面所",
+    "KITCHEN": "キッチン",
+    "DINING": "ダイニング",
+    "LIVING": "リビング",
+    "BEDROOM": "寝室",
+    "HALL": "廊下",
+    "LDK": "LDK",
+}
+
+SELF_CLOSING_MOVE_TO_RE = re.compile(r"<move_to\s+room_name=['\"](.*?)['\"]\s*/>", re.IGNORECASE)
+
 def strip_tags(text: str) -> str:
     return TAG_RE.sub("", text or "").strip()
 
@@ -10,9 +22,18 @@ def extract_between(tag: str, text: str) -> str | None:
     m = re.search(fr"<{tag}>([\s\S]*?)</{tag}>", text or "", re.IGNORECASE)
     return m.group(1).strip() if m else None
 
+def _normalize_step(step: str) -> str:
+    def repl(match: re.Match) -> str:
+        room = match.group(1).strip()
+        jp = ROOM_TRANSLATIONS.get(room.upper(), room)
+        return f"<move_to>{jp}</move_to>"
+
+    return SELF_CLOSING_MOVE_TO_RE.sub(repl, step)
+
 def parse_step(step):
+    step = _normalize_step(step.strip())
     # <move_to>BEDROOM</move_to> → move_to("BEDROOM")
-    m = re.match(r"<(\w+)>(.*?)</\1>", step.strip())
+    m = re.match(r"<(\w+)>(.*?)</\1>", step)
     if m:
         func = m.group(1)
         arg = m.group(2).strip()


### PR DESCRIPTION
## Summary
- support self-closing `<move_to room_name="..."/>` tags by normalizing them into `<move_to>...</move_to>`
- translate common English room names to Japanese equivalents during normalization
- ensure parsing handles both formats seamlessly

## Testing
- `pytest`
- `python - <<'PY'
from strips import parse_step
print(parse_step('<move_to room_name="BATHROOM"/>'))
print(parse_step('<move_to room_name="KITCHEN"/>'))
print(parse_step('<move_to>BEDROOM</move_to>'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b6cabc8d6c8320b95f666b94734e9d