### PR TITLE
Add evaluation form and save scores to experiment results

### DIFF
--- a/jsonl.py
+++ b/jsonl.py
@@ -136,8 +136,14 @@ def save_pre_experiment_result(human_score: int):
             f.write("\n")
         f.write(json.dumps(entry, ensure_ascii=False) + "\n")
 
-def save_experiment_1_result(human_score: int):
-    """保存済みコンテキストから実験結果をjsonl形式で保存"""
+def save_experiment_1_result(human_scores: dict):
+    """保存済みコンテキストから実験結果をjsonl形式で保存
+
+    Parameters
+    ----------
+    human_scores: dict
+        4段階評価の結果を格納した辞書。各質問項目をキー、評価を値として渡す。
+    """
     instruction = next((m["content"] for m in st.session_state.context if m["role"] == "user"), "")
     last_assistant = next((m["content"] for m in reversed(st.session_state.context) if m["role"] == "assistant"), "")
 
@@ -175,7 +181,7 @@ def save_experiment_1_result(human_score: int):
         "user_answers": user_answers,
         "final_output": final_output,
         "similarity": similarity,
-        "human_score": human_score,
+        "human_scores": human_scores,
     }
 
     if "saved_jsonl" not in st.session_state:

--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -18,7 +18,7 @@ from run_and_show import (
     show_clarifying_question,
     run_plan_and_show,
 )
-from jsonl import save_jsonl_entry_with_model, save_pre_experiment_result
+from jsonl import save_jsonl_entry_with_model, save_experiment_1_result
 from run_and_show import show_provisional_output
 from room_utils import detect_rooms_in_text, attach_images_for_rooms
 from pathlib import Path
@@ -96,54 +96,63 @@ def app():
     if label == "sufficient":
         st.success("モデルがsufficientを出力したため終了します。")
 
-        st.write("使う関数は適切か（不要なものが含まれている / 違う関数の方が適切）（1-4）")
-        cols = st.columns(4)
-        for idx, col in enumerate(cols, start=1):
-            if col.button(str(idx), key=f"feasibility_{idx}"):
-                save_pre_experiment_result(idx)
-                st.session_state.active = False
-        st.write("関数の変数は適切か（間違ったオブジェクトが入っている / もっと良い変数がある）（1-4）")
-        cols = st.columns(4)
-        for idx, col in enumerate(cols, start=1):
-            if col.button(str(idx), key=f"variables_{idx}"):
-                save_pre_experiment_result(idx)
-                st.session_state.active = False
-        st.write("関数の変数の具体性（1-4）")
-        cols = st.columns(4)
-        for idx, col in enumerate(cols, start=1):
-            if col.button(str(idx), key=f"specificity_{idx}"):
-                save_pre_experiment_result(idx)
-                st.session_state.active = False
-        st.write("実際にはないもの・伝えていない情報を含めていないか（1-4）")
-        cols = st.columns(4)
-        for idx, col in enumerate(cols, start=1):
-            if col.button(str(idx), key=f"hallucination_{idx}"):
-                save_pre_experiment_result(idx)
-                st.session_state.active = False
-        st.write("聞いたことがすべて盛り込まれているか（1-4）")
-        cols = st.columns(4)
-        for idx, col in enumerate(cols, start=1):
-            if col.button(str(idx), key=f"coverage_{idx}"):
-                save_pre_experiment_result(idx)
-                st.session_state.active = False
-        st.write("障害物があれば、避けられるか（1-4）")
-        cols = st.columns(4)
-        for idx, col in enumerate(cols, start=1):
-            if col.button(str(idx), key=f"obstacle_{idx}"):
-                save_pre_experiment_result(idx)
-                st.session_state.active = False
-        st.write("複数のものがある中で適切なものが選べるか（1-4）")
-        cols = st.columns(4)
-        for idx, col in enumerate(cols, start=1):
-            if col.button(str(idx), key=f"selection_{idx}"):
-                save_pre_experiment_result(idx)
-                st.session_state.active = False
-        st.write("会話の中で余計な質問・不自然な質問があったか（1-4）")
-        cols = st.columns(4)
-        for idx, col in enumerate(cols, start=1):
-            if col.button(str(idx), key=f"extra_question_{idx}"):
-                save_pre_experiment_result(idx)
-                st.session_state.active = False
+        with st.form("evaluation_form"):
+            feasibility = st.radio(
+                "使う関数は適切か（不要なものが含まれている / 違う関数の方が適切）（1-4）",
+                [1, 2, 3, 4],
+                horizontal=True,
+            )
+            variables = st.radio(
+                "関数の変数は適切か（間違ったオブジェクトが入っている / もっと良い変数がある）（1-4）",
+                [1, 2, 3, 4],
+                horizontal=True,
+            )
+            specificity = st.radio(
+                "関数の変数の具体性（1-4）",
+                [1, 2, 3, 4],
+                horizontal=True,
+            )
+            hallucination = st.radio(
+                "実際にはないもの・伝えていない情報を含めていないか（1-4）",
+                [1, 2, 3, 4],
+                horizontal=True,
+            )
+            coverage = st.radio(
+                "聞いたことがすべて盛り込まれているか（1-4）",
+                [1, 2, 3, 4],
+                horizontal=True,
+            )
+            obstacle = st.radio(
+                "障害物があれば、避けられるか（1-4）",
+                [1, 2, 3, 4],
+                horizontal=True,
+            )
+            selection = st.radio(
+                "複数のものがある中で適切なものが選べるか（1-4）",
+                [1, 2, 3, 4],
+                horizontal=True,
+            )
+            extra_question = st.radio(
+                "会話の中で余計な質問・不自然な質問があったか（1-4）",
+                [1, 2, 3, 4],
+                horizontal=True,
+            )
+            submitted = st.form_submit_button("評価を保存")
+
+        if submitted:
+            scores = {
+                "feasibility": feasibility,
+                "variables": variables,
+                "specificity": specificity,
+                "hallucination": hallucination,
+                "coverage": coverage,
+                "obstacle": obstacle,
+                "selection": selection,
+                "extra_question": extra_question,
+            }
+            save_experiment_1_result(scores)
+            st.session_state.active = False
+
         if st.session_state.active == False:
             st.warning("会話を終了しました。ありがとうございました！")
             if st.button("会話をリセット", key="reset_conv"):


### PR DESCRIPTION
## Summary
- Replace multiple evaluation buttons with a single Streamlit form for eight 4-point ratings in Experiment 1
- Persist submitted evaluation scores to `experiment_1_results.jsonl`
- Allow `save_experiment_1_result` to accept and store a dictionary of scores

## Testing
- `python -m py_compile pages/experiment_1.py jsonl.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf6c7b62b08320897b6662801b831c