### PR TITLE
Add mode selection and mode logging

### DIFF
--- a/jsonl.py
+++ b/jsonl.py
@@ -22,7 +22,8 @@ def save_jsonl_entry(label: str):
         "instruction": instruction,
         "function_sequence": function_sequence,
         "information": information,
-        "label": label
+        "label": label,
+        "mode": st.session_state.get("mode", "")
     }
     if "saved_jsonl" not in st.session_state:
         st.session_state.saved_jsonl = []
@@ -60,7 +61,8 @@ def save_jsonl_entry_with_model():
         "instruction": instruction,
         "function_sequence": function_sequence,
         "final_output": final_output,
-        "label": label
+        "label": label,
+        "mode": st.session_state.get("mode", "")
     }
     if "saved_jsonl" not in st.session_state:
         st.session_state.saved_jsonl = []
@@ -119,6 +121,7 @@ def save_pre_experiment_result(human_score: int):
         "final_output": final_output,
         "similarity": similarity,
         "human_score": human_score,
+        "mode": st.session_state.get("mode", "")
     }
 
     if "saved_jsonl" not in st.session_state:
@@ -182,6 +185,7 @@ def save_experiment_1_result(human_scores: dict):
         "final_output": final_output,
         "similarity": similarity,
         "human_scores": human_scores,
+        "mode": st.session_state.get("mode", "")
     }
 
     if "saved_jsonl" not in st.session_state:


### PR DESCRIPTION
## Summary
- Allow choosing between GPT mode (7 turns max) and GPT with critic mode in experiment 1
- Track turn counts and end conversations based on selected mode
- Record mode in JSONL logs and experiment results

## Testing
- `python -m py_compile pages/experiment_1.py jsonl.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf744722b8832089c5861457ff070e