### PR TITLE
feat: add nested image folder selection

### DIFF
--- a/move_functions.py
+++ b/move_functions.py
@@ -36,8 +36,11 @@ def _room_to_path(room_name: str) -> str:
     fname = f"{room_name.lower()}.png"  # "KITCHEN" -> "kitchen.png"
     image_dir = DEFAULT_IMAGE_DIR
     house = st.session_state.get("selected_house")
+    subfolder = st.session_state.get("selected_subfolder")
     if house:
         image_dir = os.path.join(image_dir, house)
+        if subfolder:
+            image_dir = os.path.join(image_dir, subfolder)
     return os.path.join(image_dir, fname)
 
 def show_room_image(room_name: str) -> str:
@@ -67,11 +70,15 @@ def get_room_image_path(room_name: str) -> str:
 
     file_name = f"{room_name.lower()}.png"
     house = st.session_state.get("selected_house")
+    subfolder = st.session_state.get("selected_subfolder")
 
     # Directories to search, in order of priority
     search_dirs = []
     if house:
-        search_dirs.append(os.path.join(DEFAULT_IMAGE_DIR, house))
+        base_dir = os.path.join(DEFAULT_IMAGE_DIR, house)
+        if subfolder:
+            search_dirs.append(os.path.join(base_dir, subfolder))
+        search_dirs.append(base_dir)
 
     # If no house is selected, search all house directories first
     if not house:

--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -42,8 +42,44 @@ def app():
     options = [default_label] + house_dirs
     current_house = st.session_state.get("selected_house", "")
     current_label = current_house if current_house else default_label
-    selected_label = st.selectbox("想定する家", options, index=options.index(current_label) if current_label in options else 0)
+    selected_label = st.selectbox(
+        "想定する家",
+        options,
+        index=options.index(current_label) if current_label in options else 0,
+    )
     st.session_state["selected_house"] = "" if selected_label == default_label else selected_label
+
+    image_dir = image_root
+    subdirs = []
+    if st.session_state["selected_house"]:
+        image_dir = os.path.join(image_dir, st.session_state["selected_house"])
+        subdirs = [d for d in os.listdir(image_dir) if os.path.isdir(os.path.join(image_dir, d))]
+    sub_default = "(default)"
+    if subdirs:
+        current_sub = st.session_state.get("selected_subfolder", "")
+        current_sub_label = current_sub if current_sub else sub_default
+        sub_options = [sub_default] + subdirs
+        sub_label = st.selectbox(
+            "フォルダ",
+            sub_options,
+            index=sub_options.index(current_sub_label) if current_sub_label in sub_options else 0,
+        )
+        st.session_state["selected_subfolder"] = "" if sub_label == sub_default else sub_label
+        if st.session_state["selected_subfolder"]:
+            image_dir = os.path.join(image_dir, st.session_state["selected_subfolder"])
+    else:
+        st.session_state["selected_subfolder"] = ""
+
+    if os.path.isdir(image_dir):
+        image_files = [
+            f
+            for f in os.listdir(image_dir)
+            if os.path.isfile(os.path.join(image_dir, f))
+            and f.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp"))
+        ]
+        if image_files:
+            selected_img = st.selectbox("表示する画像", image_files)
+            st.image(os.path.join(image_dir, selected_img), caption=selected_img)
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if (

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -105,8 +105,44 @@ def app():
     options = [default_label] + house_dirs
     current_house = st.session_state.get("selected_house", "")
     current_label = current_house if current_house else default_label
-    selected_label = st.selectbox("想定する家", options, index=options.index(current_label) if current_label in options else 0)
+    selected_label = st.selectbox(
+        "想定する家",
+        options,
+        index=options.index(current_label) if current_label in options else 0,
+    )
     st.session_state["selected_house"] = "" if selected_label == default_label else selected_label
+
+    image_dir = image_root
+    subdirs = []
+    if st.session_state["selected_house"]:
+        image_dir = os.path.join(image_dir, st.session_state["selected_house"])
+        subdirs = [d for d in os.listdir(image_dir) if os.path.isdir(os.path.join(image_dir, d))]
+    sub_default = "(default)"
+    if subdirs:
+        current_sub = st.session_state.get("selected_subfolder", "")
+        current_sub_label = current_sub if current_sub else sub_default
+        sub_options = [sub_default] + subdirs
+        sub_label = st.selectbox(
+            "フォルダ",
+            sub_options,
+            index=sub_options.index(current_sub_label) if current_sub_label in sub_options else 0,
+        )
+        st.session_state["selected_subfolder"] = "" if sub_label == sub_default else sub_label
+        if st.session_state["selected_subfolder"]:
+            image_dir = os.path.join(image_dir, st.session_state["selected_subfolder"])
+    else:
+        st.session_state["selected_subfolder"] = ""
+
+    if os.path.isdir(image_dir):
+        image_files = [
+            f
+            for f in os.listdir(image_dir)
+            if os.path.isfile(os.path.join(image_dir, f))
+            and f.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp"))
+        ]
+        if image_files:
+            selected_img = st.selectbox("表示する画像", image_files)
+            st.image(os.path.join(image_dir, selected_img), caption=selected_img)
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if (

--- a/pages/pre-experiment.py
+++ b/pages/pre-experiment.py
@@ -101,8 +101,44 @@ def app():
     options = [default_label] + house_dirs
     current_house = st.session_state.get("selected_house", "")
     current_label = current_house if current_house else default_label
-    selected_label = st.selectbox("想定する家", options, index=options.index(current_label) if current_label in options else 0)
+    selected_label = st.selectbox(
+        "想定する家",
+        options,
+        index=options.index(current_label) if current_label in options else 0,
+    )
     st.session_state["selected_house"] = "" if selected_label == default_label else selected_label
+
+    image_dir = image_root
+    subdirs = []
+    if st.session_state["selected_house"]:
+        image_dir = os.path.join(image_dir, st.session_state["selected_house"])
+        subdirs = [d for d in os.listdir(image_dir) if os.path.isdir(os.path.join(image_dir, d))]
+    sub_default = "(default)"
+    if subdirs:
+        current_sub = st.session_state.get("selected_subfolder", "")
+        current_sub_label = current_sub if current_sub else sub_default
+        sub_options = [sub_default] + subdirs
+        sub_label = st.selectbox(
+            "フォルダ",
+            sub_options,
+            index=sub_options.index(current_sub_label) if current_sub_label in sub_options else 0,
+        )
+        st.session_state["selected_subfolder"] = "" if sub_label == sub_default else sub_label
+        if st.session_state["selected_subfolder"]:
+            image_dir = os.path.join(image_dir, st.session_state["selected_subfolder"])
+    else:
+        st.session_state["selected_subfolder"] = ""
+
+    if os.path.isdir(image_dir):
+        image_files = [
+            f
+            for f in os.listdir(image_dir)
+            if os.path.isfile(os.path.join(image_dir, f))
+            and f.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp"))
+        ]
+        if image_files:
+            selected_img = st.selectbox("表示する画像", image_files)
+            st.image(os.path.join(image_dir, selected_img), caption=selected_img)
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if (

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -34,8 +34,44 @@ def app():
     options = [default_label] + house_dirs
     current_house = st.session_state.get("selected_house", "")
     current_label = current_house if current_house else default_label
-    selected_label = st.selectbox("想定する家", options, index=options.index(current_label) if current_label in options else 0)
+    selected_label = st.selectbox(
+        "想定する家",
+        options,
+        index=options.index(current_label) if current_label in options else 0,
+    )
     st.session_state["selected_house"] = "" if selected_label == default_label else selected_label
+
+    image_dir = image_root
+    subdirs = []
+    if st.session_state["selected_house"]:
+        image_dir = os.path.join(image_dir, st.session_state["selected_house"])
+        subdirs = [d for d in os.listdir(image_dir) if os.path.isdir(os.path.join(image_dir, d))]
+    sub_default = "(default)"
+    if subdirs:
+        current_sub = st.session_state.get("selected_subfolder", "")
+        current_sub_label = current_sub if current_sub else sub_default
+        sub_options = [sub_default] + subdirs
+        sub_label = st.selectbox(
+            "フォルダ",
+            sub_options,
+            index=sub_options.index(current_sub_label) if current_sub_label in sub_options else 0,
+        )
+        st.session_state["selected_subfolder"] = "" if sub_label == sub_default else sub_label
+        if st.session_state["selected_subfolder"]:
+            image_dir = os.path.join(image_dir, st.session_state["selected_subfolder"])
+    else:
+        st.session_state["selected_subfolder"] = ""
+
+    if os.path.isdir(image_dir):
+        image_files = [
+            f
+            for f in os.listdir(image_dir)
+            if os.path.isfile(os.path.join(image_dir, f))
+            and f.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp"))
+        ]
+        if image_files:
+            selected_img = st.selectbox("表示する画像", image_files)
+            st.image(os.path.join(image_dir, selected_img), caption=selected_img)
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if "context" not in st.session_state:


### PR DESCRIPTION
## Summary
- allow choosing nested image folders and previewing a selected image in the main app and all pages
- extend room image lookup to respect an optional subfolder

## Testing
- `python -m py_compile move_functions.py streamlit_app.py pages/pre-experiment.py pages/experiment_1.py pages/experiment_2.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bff61fe8f88320972aa273aa4f4c00