### PR TITLE
Use selected image for AI context

### DIFF
--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -7,11 +7,9 @@ from move_functions import (
     pick_object,
     place_object_next_to,
     place_object_on,
-    show_room_image,
-    get_room_image_path,
 )
 from dotenv import load_dotenv
-from api import client, SYSTEM_PROMPT
+from api import client, SYSTEM_PROMPT, build_bootstrap_user_message
 from strips import strip_tags, extract_between
 from run_and_show import (
     show_function_sequence,
@@ -20,7 +18,6 @@ from run_and_show import (
 )
 from jsonl import predict_with_model, save_experiment_1_result
 from run_and_show import show_provisional_output
-from room_utils import detect_rooms_in_text, attach_images_for_rooms
 from pathlib import Path
 
 load_dotenv()
@@ -79,7 +76,9 @@ def app():
         ]
         if image_files:
             selected_img = st.selectbox("表示する画像", image_files)
-            st.image(os.path.join(image_dir, selected_img), caption=selected_img)
+            selected_path = os.path.join(image_dir, selected_img)
+            st.session_state["selected_image_path"] = selected_path
+            st.image(selected_path, caption=selected_img)
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if (
@@ -96,8 +95,6 @@ def app():
         st.session_state.turn_count = 0
     if "active" not in st.session_state:
         st.session_state.active = True
-    if "sent_room_images" not in st.session_state:
-        st.session_state.sent_room_images = set()
     if "turn_count" not in st.session_state:
         st.session_state.turn_count = 0
 
@@ -110,8 +107,14 @@ def app():
     
     if user_input:
         context.append({"role": "user", "content": user_input})
-        rooms_from_user = detect_rooms_in_text(user_input)
-        attach_images_for_rooms(rooms_from_user)
+        selected_path = st.session_state.get("selected_image_path")
+        if selected_path:
+            context.append(
+                build_bootstrap_user_message(
+                    text="Here is the selected image. Use it for scene understanding and disambiguation.",
+                    local_image_paths=[selected_path],
+                )
+            )
         response = client.chat.completions.create(
             model="gpt-4o-mini",
             messages=context
@@ -119,8 +122,6 @@ def app():
         reply = response.choices[0].message.content.strip()
         print("Assistant:", reply)
         context.append({"role": "assistant", "content": reply})
-        rooms_from_assistant = detect_rooms_in_text(reply)
-        attach_images_for_rooms(rooms_from_assistant)
         print("context: ", context)
         st.session_state.turn_count += 1
         

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -3,7 +3,7 @@ import re
 import json
 import os
 import joblib
-from move_functions import move_to, pick_object, place_object_next_to, place_object_on, show_room_image, get_room_image_path
+from move_functions import move_to, pick_object, place_object_next_to, place_object_on
 from openai import OpenAI
 from dotenv import load_dotenv
 from api import (
@@ -11,11 +11,11 @@ from api import (
     SYSTEM_PROMPT_STANDARD,
     SYSTEM_PROMPT_FRIENDLY,
     SYSTEM_PROMPT_PRATFALL,
+    build_bootstrap_user_message,
 )
 from jsonl import predict_with_model, save_experiment_2_result
 from run_and_show import show_function_sequence, show_clarifying_question, run_plan_and_show
 from two_classify import prepare_data  # 既存関数を利用
-from room_utils import detect_rooms_in_text, attach_images_for_rooms
 
 load_dotenv()
 
@@ -142,7 +142,9 @@ def app():
         ]
         if image_files:
             selected_img = st.selectbox("表示する画像", image_files)
-            st.image(os.path.join(image_dir, selected_img), caption=selected_img)
+            selected_path = os.path.join(image_dir, selected_img)
+            st.session_state["selected_image_path"] = selected_path
+            st.image(selected_path, caption=selected_img)
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if (
@@ -158,8 +160,6 @@ def app():
         }
     if "active" not in st.session_state:
         st.session_state.active = True
-    if "sent_room_images" not in st.session_state:
-        st.session_state.sent_room_images = set()
 
     context = st.session_state["context"]
 
@@ -168,8 +168,14 @@ def app():
     user_input = st.chat_input("ロボットへの指示や回答を入力してください")
     if user_input:
         context.append({"role": "user", "content": user_input})
-        rooms_from_user = detect_rooms_in_text(user_input)
-        attach_images_for_rooms(rooms_from_user)
+        selected_path = st.session_state.get("selected_image_path")
+        if selected_path:
+            context.append(
+                build_bootstrap_user_message(
+                    text="Here is the selected image. Use it for scene understanding and disambiguation.",
+                    local_image_paths=[selected_path],
+                )
+            )
         response = client.chat.completions.create(
             model="gpt-4o-mini",
             messages=context
@@ -177,8 +183,6 @@ def app():
         reply = response.choices[0].message.content.strip()
         print("Assistant:", reply)
         context.append({"role": "assistant", "content": reply})
-        rooms_from_assistant = detect_rooms_in_text(reply)
-        attach_images_for_rooms(rooms_from_assistant)
         print("context: ", context)
 
         run_plan_and_show(reply)

--- a/pages/pre-experiment.py
+++ b/pages/pre-experiment.py
@@ -7,11 +7,9 @@ from move_functions import (
     pick_object,
     place_object_next_to,
     place_object_on,
-    show_room_image,
-    get_room_image_path,
 )
 from dotenv import load_dotenv
-from api import client, SYSTEM_PROMPT
+from api import client, SYSTEM_PROMPT, build_bootstrap_user_message
 from strips import strip_tags, extract_between
 from run_and_show import (
     show_function_sequence,
@@ -20,7 +18,6 @@ from run_and_show import (
 )
 from jsonl import predict_with_model, save_pre_experiment_result
 from run_and_show import show_provisional_output
-from room_utils import detect_rooms_in_text, attach_images_for_rooms
 from pathlib import Path
 
 load_dotenv()
@@ -138,7 +135,9 @@ def app():
         ]
         if image_files:
             selected_img = st.selectbox("表示する画像", image_files)
-            st.image(os.path.join(image_dir, selected_img), caption=selected_img)
+            selected_path = os.path.join(image_dir, selected_img)
+            st.session_state["selected_image_path"] = selected_path
+            st.image(selected_path, caption=selected_img)
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if (
@@ -154,8 +153,6 @@ def app():
         }
     if "active" not in st.session_state:
         st.session_state.active = True
-    if "sent_room_images" not in st.session_state:
-        st.session_state.sent_room_images = set()
 
     gt_map = load_ground_truth_map()
     inst_options = ["(未選択)"] + list(gt_map.keys())
@@ -181,8 +178,14 @@ def app():
     
     if user_input:
         context.append({"role": "user", "content": user_input})
-        rooms_from_user = detect_rooms_in_text(user_input)
-        attach_images_for_rooms(rooms_from_user)
+        selected_path = st.session_state.get("selected_image_path")
+        if selected_path:
+            context.append(
+                build_bootstrap_user_message(
+                    text="Here is the selected image. Use it for scene understanding and disambiguation.",
+                    local_image_paths=[selected_path],
+                )
+            )
         response = client.chat.completions.create(
             model="gpt-4o-mini",
             messages=context
@@ -190,8 +193,6 @@ def app():
         reply = response.choices[0].message.content.strip()
         print("Assistant:", reply)
         context.append({"role": "assistant", "content": reply})
-        rooms_from_assistant = detect_rooms_in_text(reply)
-        attach_images_for_rooms(rooms_from_assistant)
         print("context: ", context)
         label = predict_with_model()
         if label == "sufficient":


### PR DESCRIPTION
## Summary
- Send the image chosen in the Streamlit UI to the AI instead of guessing rooms
- Apply the same image selection logic across all experiment pages

## Testing
- `python -m py_compile streamlit_app.py pages/*.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bffad32dc08320a665435e29d30854