### PR TITLE
Accumulate information across updates

### DIFF
--- a/run_and_show.py
+++ b/run_and_show.py
@@ -23,12 +23,21 @@ def show_clarifying_question(reply: str):
 
 
 def show_information(reply: str):
-    """<Information> ... </Information> の内容を箇条書きで表示"""
+    """<Information> ... </Information> を蓄積して表示"""
     info_match = re.search(r"<Information>([\s\S]*?)</Information>", reply, re.IGNORECASE)
     if not info_match:
         return
+
+    items = re.findall(r"<li>(.*?)</li>", info_match.group(1))
+    if "information_items" not in st.session_state:
+        st.session_state.information_items = []
+    for item in items:
+        if item not in st.session_state.information_items:
+            st.session_state.information_items.append(item)
+
+    aggregated = "".join(f"<li>{item}</li>" for item in st.session_state.information_items)
     st.subheader("Information")
-    st.markdown("<ul>" + info_match.group(1).strip() + "</ul>", unsafe_allow_html=True)
+    st.markdown("<ul>" + aggregated + "</ul>", unsafe_allow_html=True)
 
 
 def show_provisional_output(reply: str):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,7 +6,7 @@ from openai import OpenAI
 from dotenv import load_dotenv
 from api import client, build_bootstrap_user_message, CREATING_DATA_SYSTEM_PROMPT
 from move_functions import move_to, pick_object, place_object_next_to, place_object_on
-from run_and_show import show_function_sequence, show_clarifying_question, run_plan_and_show
+from run_and_show import show_function_sequence, show_clarifying_question, run_plan_and_show, show_information
 from jsonl import save_jsonl_entry, show_jsonl_block, save_pre_experiment_result
 
 load_dotenv()
@@ -163,6 +163,7 @@ def app():
                     run_plan_and_show(msg["content"])
                 show_function_sequence(msg["content"])
                 show_clarifying_question(msg["content"])
+                show_information(msg["content"])
         # 最後のアシスタント直後にボタンを出す（計画があるときのみ）
         if i == last_assistant_idx and "<FunctionSequence>" in msg["content"]:
             st.write("この計画はロボットが実行するのに十分ですか？")


### PR DESCRIPTION
## Summary
- preserve previously extracted `<Information>` items and append only new ones for display
- show aggregated information in chat history alongside existing plan and clarifying question details

## Testing
- `python -m py_compile run_and_show.py streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c13ea3f2308320a90650130fb7afbb