### PR TITLE
Handle missing Firestore credentials file

### DIFF
--- a/jsonl.py
+++ b/jsonl.py
@@ -25,6 +25,9 @@ def _save_to_firestore(entry, collection_override=None):
     if not credentials:
         print("[Firestore] skipped: no FIREBASE_CREDENTIALS")
         return
+    if not Path(credentials).exists():
+        print(f"[Firestore] skipped: credentials file not found at {credentials}")
+        return
     try:
         save_document(collection, entry, credentials)
         print(f"[Firestore] saved to {collection}")


### PR DESCRIPTION
## Summary
- Avoid FileNotFoundError when Firebase credentials path is missing
- Log a clear message and skip Firestore save when credentials file is absent

## Testing
- `python -m py_compile jsonl.py`


------
https://chatgpt.com/codex/tasks/task_e_68c15a3d568c8320a4760206a726d0bb