### PR TITLE
Support multiple image selection

### DIFF
--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -85,10 +85,13 @@ def app():
             and f.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp"))
         ]
         if image_files:
-            selected_img = st.selectbox("表示する画像", image_files)
-            selected_path = os.path.join(image_dir, selected_img)
-            st.session_state["selected_image_path"] = selected_path
-            st.image(selected_path, caption=selected_img)
+            selected_imgs = st.multiselect("表示する画像", image_files)
+            selected_paths = [os.path.join(image_dir, img) for img in selected_imgs]
+            st.session_state["selected_image_paths"] = selected_paths
+            for path, img in zip(selected_paths, selected_imgs):
+                st.image(path, caption=img)
+        else:
+            st.session_state["selected_image_paths"] = []
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if (
@@ -117,12 +120,12 @@ def app():
     
     if user_input:
         context.append({"role": "user", "content": user_input})
-        selected_path = st.session_state.get("selected_image_path")
-        if selected_path:
+        selected_paths = st.session_state.get("selected_image_paths", [])
+        if selected_paths:
             context.append(
                 build_bootstrap_user_message(
-                    text="Here is the selected image. Use it for scene understanding and disambiguation.",
-                    local_image_paths=[selected_path],
+                    text="Here are the selected images. Use them for scene understanding and disambiguation.",
+                    local_image_paths=selected_paths,
                 )
             )
         response = client.chat.completions.create(

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -150,10 +150,13 @@ def app():
             and f.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp"))
         ]
         if image_files:
-            selected_img = st.selectbox("表示する画像", image_files)
-            selected_path = os.path.join(image_dir, selected_img)
-            st.session_state["selected_image_path"] = selected_path
-            st.image(selected_path, caption=selected_img)
+            selected_imgs = st.multiselect("表示する画像", image_files)
+            selected_paths = [os.path.join(image_dir, img) for img in selected_imgs]
+            st.session_state["selected_image_paths"] = selected_paths
+            for path, img in zip(selected_paths, selected_imgs):
+                st.image(path, caption=img)
+        else:
+            st.session_state["selected_image_paths"] = []
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if (
@@ -177,12 +180,12 @@ def app():
     user_input = st.chat_input("ロボットへの指示や回答を入力してください")
     if user_input:
         context.append({"role": "user", "content": user_input})
-        selected_path = st.session_state.get("selected_image_path")
-        if selected_path:
+        selected_paths = st.session_state.get("selected_image_paths", [])
+        if selected_paths:
             context.append(
                 build_bootstrap_user_message(
-                    text="Here is the selected image. Use it for scene understanding and disambiguation.",
-                    local_image_paths=[selected_path],
+                    text="Here are the selected images. Use them for scene understanding and disambiguation.",
+                    local_image_paths=selected_paths,
                 )
             )
         response = client.chat.completions.create(

--- a/pages/pre-experiment.py
+++ b/pages/pre-experiment.py
@@ -144,10 +144,13 @@ def app():
             and f.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp"))
         ]
         if image_files:
-            selected_img = st.selectbox("表示する画像", image_files)
-            selected_path = os.path.join(image_dir, selected_img)
-            st.session_state["selected_image_path"] = selected_path
-            st.image(selected_path, caption=selected_img)
+            selected_imgs = st.multiselect("表示する画像", image_files)
+            selected_paths = [os.path.join(image_dir, img) for img in selected_imgs]
+            st.session_state["selected_image_paths"] = selected_paths
+            for path, img in zip(selected_paths, selected_imgs):
+                st.image(path, caption=img)
+        else:
+            st.session_state["selected_image_paths"] = []
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if (
@@ -188,12 +191,12 @@ def app():
     
     if user_input:
         context.append({"role": "user", "content": user_input})
-        selected_path = st.session_state.get("selected_image_path")
-        if selected_path:
+        selected_paths = st.session_state.get("selected_image_paths", [])
+        if selected_paths:
             context.append(
                 build_bootstrap_user_message(
-                    text="Here is the selected image. Use it for scene understanding and disambiguation.",
-                    local_image_paths=[selected_path],
+                    text="Here are the selected images. Use them for scene understanding and disambiguation.",
+                    local_image_paths=selected_paths,
                 )
             )
         response = client.chat.completions.create(

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -69,10 +69,13 @@ def app():
             and f.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp"))
         ]
         if image_files:
-            selected_img = st.selectbox("表示する画像", image_files)
-            selected_path = os.path.join(image_dir, selected_img)
-            st.session_state["selected_image_path"] = selected_path
-            st.image(selected_path, caption=selected_img)
+            selected_imgs = st.multiselect("表示する画像", image_files)
+            selected_paths = [os.path.join(image_dir, img) for img in selected_imgs]
+            st.session_state["selected_image_paths"] = selected_paths
+            for path, img in zip(selected_paths, selected_imgs):
+                st.image(path, caption=img)
+        else:
+            st.session_state["selected_image_paths"] = []
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if "context" not in st.session_state:
@@ -107,12 +110,12 @@ def app():
             st.success(f"ロボットへの指示がセットされました：**{instruction}**")
             context.append({"role": "user", "content": instruction})
 
-            selected_path = st.session_state.get("selected_image_path")
-            if selected_path:
+            selected_paths = st.session_state.get("selected_image_paths", [])
+            if selected_paths:
                 context.append(
                     build_bootstrap_user_message(
-                        text="Here is the selected image. Use it for scene understanding and disambiguation.",
-                        local_image_paths=[selected_path],
+                        text="Here are the selected images. Use them for scene understanding and disambiguation.",
+                        local_image_paths=selected_paths,
                     )
                 )
 
@@ -131,12 +134,12 @@ def app():
     user_input = st.chat_input("入力してください")
     if user_input:
         context.append({"role": "user", "content": user_input})
-        selected_path = st.session_state.get("selected_image_path")
-        if selected_path:
+        selected_paths = st.session_state.get("selected_image_paths", [])
+        if selected_paths:
             context.append(
                 build_bootstrap_user_message(
-                    text="Here is the selected image. Use it for scene understanding and disambiguation.",
-                    local_image_paths=[selected_path],
+                    text="Here are the selected images. Use them for scene understanding and disambiguation.",
+                    local_image_paths=selected_paths,
                 )
             )
         response = client.chat.completions.create(


### PR DESCRIPTION
## Summary
- Allow selecting multiple images in main and experiment Streamlit pages
- Forward all selected images to the OpenAI chat context

## Testing
- `python -m py_compile streamlit_app.py pages/experiment_1.py pages/experiment_2.py pages/pre-experiment.py`


------
https://chatgpt.com/codex/tasks/task_e_68c24b95cf4c832081206faaa8252081