### PR TITLE
Isolate Streamlit session state per page with prefixes

### DIFF
--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -9,6 +9,7 @@ from move_functions import (
     place_object_on,
 )
 from dotenv import load_dotenv
+from session_state_utils import PrefixedSessionState
 from api import client, SYSTEM_PROMPT, build_bootstrap_user_message
 from strips import strip_tags, extract_between
 from run_and_show import (
@@ -21,6 +22,8 @@ from run_and_show import show_provisional_output
 from pathlib import Path
 
 load_dotenv()
+base_state = getattr(st.session_state, "_PrefixedSessionState__base", st.session_state)
+st.session_state = PrefixedSessionState(base_state, "exp1_")
 
 def app():
     st.title("LLMATCHデモアプリ")

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -6,6 +6,7 @@ import joblib
 from move_functions import move_to, pick_object, place_object_next_to, place_object_on
 from openai import OpenAI
 from dotenv import load_dotenv
+from session_state_utils import PrefixedSessionState
 from api import (
     client,
     SYSTEM_PROMPT_STANDARD,
@@ -18,6 +19,8 @@ from run_and_show import show_function_sequence, show_clarifying_question, run_p
 from two_classify import prepare_data  # 既存関数を利用
 
 load_dotenv()
+base_state = getattr(st.session_state, "_PrefixedSessionState__base", st.session_state)
+st.session_state = PrefixedSessionState(base_state, "exp2_")
 
 TAG_RE = re.compile(r"</?([A-Za-z0-9_]+)(\s[^>]*)?>")
 

--- a/pages/pre-experiment.py
+++ b/pages/pre-experiment.py
@@ -9,6 +9,7 @@ from move_functions import (
     place_object_on,
 )
 from dotenv import load_dotenv
+from session_state_utils import PrefixedSessionState
 from api import client, SYSTEM_PROMPT, build_bootstrap_user_message
 from strips import strip_tags, extract_between
 from run_and_show import (
@@ -21,6 +22,8 @@ from run_and_show import show_provisional_output
 from pathlib import Path
 
 load_dotenv()
+base_state = getattr(st.session_state, "_PrefixedSessionState__base", st.session_state)
+st.session_state = PrefixedSessionState(base_state, "pre_")
 
 @st.cache_data
 def load_ground_truth_map():

--- a/session_state_utils.py
+++ b/session_state_utils.py
@@ -1,0 +1,40 @@
+class PrefixedSessionState:
+    """Wrap an existing SessionState and prefix all keys.
+
+    By assigning `st.session_state = PrefixedSessionState(st.session_state, "pre_")`
+    each Streamlit page can maintain its own namespace without key collisions.
+    """
+    def __init__(self, base_state, prefix: str):
+        super().__setattr__('__base', base_state)
+        super().__setattr__('prefix', prefix)
+
+    def _k(self, key: str) -> str:
+        return f"{self.prefix}{key}"
+
+    # Dictionary-style access
+    def __getitem__(self, key):
+        return self.__base[self._k(key)]
+
+    def __setitem__(self, key, value):
+        self.__base[self._k(key)] = value
+
+    def __contains__(self, key):
+        return self._k(key) in self.__base
+
+    def get(self, key, default=None):
+        return self.__base.get(self._k(key), default)
+
+    def pop(self, key, default=None):
+        return self.__base.pop(self._k(key), default)
+
+    # Attribute-style access
+    def __getattr__(self, key):
+        if key in {'__base', 'prefix'}:
+            return super().__getattribute__(key)
+        return self.__base[self._k(key)]
+
+    def __setattr__(self, key, value):
+        if key in {'__base', 'prefix'}:
+            super().__setattr__(key, value)
+        else:
+            self.__base[self._k(key)] = value

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -4,12 +4,15 @@ import os
 import re
 from openai import OpenAI
 from dotenv import load_dotenv
+from session_state_utils import PrefixedSessionState
 from api import client, build_bootstrap_user_message, CREATING_DATA_SYSTEM_PROMPT
 from move_functions import move_to, pick_object, place_object_next_to, place_object_on
 from run_and_show import show_function_sequence, show_clarifying_question, show_information, run_plan_and_show
 from jsonl import save_jsonl_entry, show_jsonl_block, save_pre_experiment_result
 
 load_dotenv()
+base_state = getattr(st.session_state, "_PrefixedSessionState__base", st.session_state)
+st.session_state = PrefixedSessionState(base_state, "app_")
 
 
 def accumulate_information(reply: str) -> str:


### PR DESCRIPTION
## Summary
- add PrefixedSessionState helper to namespace session_state keys
- wrap session_state in each Streamlit page with unique prefixes (`app_`, `pre_`, `exp1_`, `exp2_`)

## Testing
- `python -m py_compile streamlit_app.py pages/pre-experiment.py pages/experiment_1.py pages/experiment_2.py session_state_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68c62db53ed883209ec85129d6226003