### PR TITLE
Decouple experiment 2 training

### DIFF
--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -87,7 +87,7 @@ def get_critic_label(context):
 def app():
     st.title("LLMATCHデモアプリ")
     st.subheader("ChatGPT with 'Critic'")
-    st.warning("このページは、再読み込み時にモデルの学習が行われるため、起動に時間がかかります。")
+    st.info("評価モデルの学習は `two_classify.py` を直接実行して行ってください。")
     
     st.sidebar.title("使用できる関数")
     st.sidebar.markdown(


### PR DESCRIPTION
## Summary
- move the critic model training logic in `two_classify.py` into reusable functions and run it only when the script is executed directly
- leave a dedicated entry point (`train_and_save_model`) for manual retraining and ensure models are stored under `models/`
- update the experiment 2 page to instruct users to execute `two_classify.py` when they wish to retrain the evaluator

## Testing
- `python -m compileall pages/experiment_2.py two_classify.py`


------
https://chatgpt.com/codex/tasks/task_e_68d31708493883209c4d11425b9285ea