### PR TITLE
Set latest evaluation model as default selection

### DIFF
--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -65,13 +65,22 @@ def app():
 
     system_prompt = SYSTEM_PROMPT
 
-    model_files = [f for f in os.listdir("models") if f.endswith(".joblib")]
+    model_files = sorted(
+        f for f in os.listdir("models") if f.endswith(".joblib")
+    )
     if model_files:
-        current_model = os.path.basename(st.session_state.get("model_path", model_files[0]))
+        latest_model = max(
+            model_files,
+            key=lambda f: os.path.getmtime(os.path.join("models", f)),
+        )
+        stored_model = st.session_state.get("model_path")
+        current_model = os.path.basename(stored_model) if stored_model else None
+        if current_model not in model_files:
+            current_model = latest_model
         selected_model = st.selectbox(
             "評価モデル",
             model_files,
-            index=model_files.index(current_model) if current_model in model_files else 0,
+            index=model_files.index(current_model),
         )
         st.session_state["model_path"] = os.path.join("models", selected_model)
 

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -129,13 +129,22 @@ def app():
     system_prompt = prompt_options[prompt_label]
     st.session_state["prompt_label"] = prompt_label
 
-    model_files = [f for f in os.listdir("models") if f.endswith(".joblib")]
+    model_files = sorted(
+        f for f in os.listdir("models") if f.endswith(".joblib")
+    )
     if model_files:
-        current_model = os.path.basename(st.session_state.get("model_path", model_files[0]))
+        latest_model = max(
+            model_files,
+            key=lambda f: os.path.getmtime(os.path.join("models", f)),
+        )
+        stored_model = st.session_state.get("model_path")
+        current_model = os.path.basename(stored_model) if stored_model else None
+        if current_model not in model_files:
+            current_model = latest_model
         selected_model = st.selectbox(
             "評価モデル",
             model_files,
-            index=model_files.index(current_model) if current_model in model_files else 0,
+            index=model_files.index(current_model),
         )
         st.session_state["model_path"] = os.path.join("models", selected_model)
 

--- a/pages/pre-experiment.py
+++ b/pages/pre-experiment.py
@@ -124,13 +124,22 @@ def app():
 
     system_prompt = SYSTEM_PROMPT
 
-    model_files = [f for f in os.listdir("models") if f.endswith(".joblib")]
+    model_files = sorted(
+        f for f in os.listdir("models") if f.endswith(".joblib")
+    )
     if model_files:
-        current_model = os.path.basename(st.session_state.get("model_path", model_files[0]))
+        latest_model = max(
+            model_files,
+            key=lambda f: os.path.getmtime(os.path.join("models", f)),
+        )
+        stored_model = st.session_state.get("model_path")
+        current_model = os.path.basename(stored_model) if stored_model else None
+        if current_model not in model_files:
+            current_model = latest_model
         selected_model = st.selectbox(
             "評価モデル",
             model_files,
-            index=model_files.index(current_model) if current_model in model_files else 0,
+            index=model_files.index(current_model),
         )
         st.session_state["model_path"] = os.path.join("models", selected_model)
 


### PR DESCRIPTION
## Summary
- ensure each experiment page sorts available evaluation models and determines the latest joblib file by modification time
- default the evaluation model selectbox to the newest file when no previous selection exists or the stored selection is missing

## Testing
- python -m compileall pages

------
https://chatgpt.com/codex/tasks/task_e_68d32f84553883208f06909ab39ae0ec