### PR TITLE
Track typed chat input responses

### DIFF
--- a/jsonl.py
+++ b/jsonl.py
@@ -273,18 +273,16 @@ def save_pre_experiment_result(human_score: int):
     information = info_match.group(1).strip() if info_match else ""
 
     clarifications = []
-    user_answers = []
     for m in st.session_state.context:
         if m["role"] == "assistant":
             q_match = re.search(r"<ClarifyingQuestion>([\s\S]*?)</ClarifyingQuestion>", m["content"], re.IGNORECASE)
             if q_match:
                 clarifications.append(q_match.group(1).strip())
-        if m["role"] == "user":
-            content = m["content"]
-            if isinstance(content, list):
-                # Join list items into a single string
-                content = " ".join(map(str, content))
-            user_answers.append(content.strip())
+    user_answers = [
+        ans.strip()
+        for ans in st.session_state.get("chat_input_history", [])
+        if ans and ans.strip()
+    ]
     text = f"instruction: {instruction} \nfs: {function_sequence}"
     similarity = None
     model_path = Path(st.session_state.get("model_path", MODEL_PATH))
@@ -361,18 +359,16 @@ def save_experiment_1_result(
         human_scores["plan_success_probability"] = success_probability
 
     clarifications = []
-    user_answers = []
     for m in st.session_state.context:
         if m["role"] == "assistant":
             q_match = re.search(r"<ClarifyingQuestion>([\s\S]*?)</ClarifyingQuestion>", m["content"], re.IGNORECASE)
             if q_match:
                 clarifications.append(q_match.group(1).strip())
-        if m["role"] == "user":
-            content = m["content"]
-            if isinstance(content, list):
-                # Join list items into a single string
-                content = " ".join(map(str, content))
-            user_answers.append(content.strip())
+    user_answers = [
+        ans.strip()
+        for ans in st.session_state.get("chat_input_history", [])
+        if ans and ans.strip()
+    ]
     text = f"instruction: {instruction} \nfs: {function_sequence}"
     # TODO: 類似度どうするか考える。プレ実験にしか含めないか、experiment_1にも含めるか
     similarity = None
@@ -389,8 +385,7 @@ def save_experiment_1_result(
         "function_sequence": function_sequence,
         "information": information,
         "clarification_question": clarifications,
-        # TODO: user_answersは保存しないか、image_urlを除いて保存するか考える
-        # "user_answers": user_answers,
+        "user_answers": user_answers,
         "similarity": similarity,
         "human_scores": human_scores,
         "mode": st.session_state.get("mode", ""),
@@ -452,18 +447,16 @@ def save_experiment_2_result(
         human_scores["plan_success_probability"] = success_probability
 
     clarifications = []
-    user_answers = []
     for m in st.session_state.context:
         if m["role"] == "assistant":
             q_match = re.search(r"<ClarifyingQuestion>([\s\S]*?)</ClarifyingQuestion>", m["content"], re.IGNORECASE)
             if q_match:
                 clarifications.append(q_match.group(1).strip())
-        if m["role"] == "user":
-            content = m["content"]
-            if isinstance(content, list):
-                # Join list items into a single string
-                content = " ".join(map(str, content))
-            user_answers.append(content.strip())
+    user_answers = [
+        ans.strip()
+        for ans in st.session_state.get("chat_input_history", [])
+        if ans and ans.strip()
+    ]
     text = f"instruction: {instruction} \nfs: {function_sequence}"
 
     entry = {
@@ -471,8 +464,7 @@ def save_experiment_2_result(
         "function_sequence": function_sequence,
         "information": information,
         "clarification_question": clarifications,
-        # TODO: user_answersは保存しないか、image_urlを除いて保存するか考える
-        # "user_answers": user_answers,
+        "user_answers": user_answers,
         "human_scores": human_scores,
         "prompt_label": st.session_state.get("prompt_label", ""),
         "termination_label": termination_label,

--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -147,6 +147,9 @@ def app():
             "clarifying_steps": []
         }
         st.session_state.turn_count = 0
+        st.session_state["chat_input_history"] = []
+    if "chat_input_history" not in st.session_state:
+        st.session_state["chat_input_history"] = []
     if "active" not in st.session_state:
         st.session_state.active = True
     if "turn_count" not in st.session_state:
@@ -164,6 +167,8 @@ def app():
         user_input = None
     else:
         input_box = st.chat_input("ロボットへの回答を入力してください")
+        if input_box:
+            st.session_state["chat_input_history"].append(input_box)
         user_input = st.session_state.pop("pending_user_input", None) or input_box
     
     if user_input:
@@ -299,6 +304,7 @@ def app():
                     st.session_state.turn_count = 0
                     st.session_state.force_end = False
                     st.session_state.end_reason = ""
+                    st.session_state["chat_input_history"] = []
                     st.rerun()
             with cols_end[1]:
                 st.button("🚨会話を強制的に終了", key="force_end_disabled", disabled=True)
@@ -319,6 +325,7 @@ def app():
             st.session_state.turn_count = 0
             st.session_state.force_end = False
             st.session_state.end_reason = ""
+            st.session_state["chat_input_history"] = []
             st.rerun()
     with cols[1]:
         if st.button("🚨会話を強制的に終了", key="force_end_button"):

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -210,12 +210,15 @@ def app():
             "label": "",
             "clarifying_steps": []
         }
+        st.session_state["chat_input_history"] = []
     if "active" not in st.session_state:
         st.session_state.active = True
     if "force_end" not in st.session_state:
         st.session_state.force_end = False
     if "end_reason" not in st.session_state:
         st.session_state.end_reason = ""
+    if "chat_input_history" not in st.session_state:
+        st.session_state["chat_input_history"] = []
 
     context = st.session_state["context"]
 
@@ -225,6 +228,8 @@ def app():
         user_input = None
     else:
         user_input = st.chat_input("ロボットへの指示や回答を入力してください")
+        if user_input:
+            st.session_state["chat_input_history"].append(user_input)
     if user_input:
         context.append({"role": "user", "content": user_input})
         selected_paths = st.session_state.get("selected_image_paths", [])
@@ -347,6 +352,7 @@ def app():
             st.session_state.saved_jsonl = []
             st.session_state.force_end = False
             st.session_state.end_reason = ""
+            st.session_state["chat_input_history"] = []
             st.rerun()
     with cols[1]:
         if st.button("🚨会話を強制的に終了", key="force_end_button"):

--- a/pages/pre-experiment.py
+++ b/pages/pre-experiment.py
@@ -205,8 +205,11 @@ def app():
             "label": "",
             "clarifying_steps": []
         }
+        st.session_state["chat_input_history"] = []
     if "active" not in st.session_state:
         st.session_state.active = True
+    if "chat_input_history" not in st.session_state:
+        st.session_state["chat_input_history"] = []
 
     gt_map = load_ground_truth_map()
     inst_options = ["(未選択)"] + list(gt_map.keys())
@@ -228,6 +231,8 @@ def app():
     message = st.chat_message("assistant")
     message.write("こんにちは、私は家庭用ロボットです！あなたの指示に従って行動します。")
     input_box = st.chat_input("ロボットへの回答を入力してください")
+    if input_box:
+        st.session_state["chat_input_history"].append(input_box)
     user_input = st.session_state.pop("pending_user_input", None) or input_box
     
     if user_input:
@@ -289,6 +294,7 @@ def app():
             "clarifying_steps": []
         }
         st.session_state.saved_jsonl = []
+        st.session_state["chat_input_history"] = []
         st.rerun()
 
 app()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -120,6 +120,10 @@ def app():
         st.session_state["context"] = [
             {"role": "system", "content": CREATING_DATA_SYSTEM_PROMPT},
         ]
+        st.session_state["chat_input_history"] = []
+
+    if "chat_input_history" not in st.session_state:
+        st.session_state["chat_input_history"] = []
 
     if "active" not in st.session_state:
         st.session_state.active = True
@@ -170,6 +174,8 @@ def app():
 
     # 3) 追加の自由入力（会話継続用）
     user_input = st.chat_input("入力してください")
+    if user_input:
+        st.session_state["chat_input_history"].append(user_input)
     if user_input:
         context.append({"role": "user", "content": user_input})
         selected_paths = st.session_state.get("selected_image_paths", [])
@@ -242,6 +248,7 @@ def app():
                     }
                     st.session_state.saved_jsonl = []
                     st.session_state.information_items = []
+                    st.session_state["chat_input_history"] = []
                     st.rerun()
                 st.stop()
 


### PR DESCRIPTION
## Summary
- record chat input strings in session state across the app when the user actually types responses
- clear the tracked chat inputs whenever a conversation is reset so only the current session's text is saved
- write experiment result JSONL entries using the recorded chat input history instead of walking the entire context

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3435eec7c8320b4d266df34d42f49