### PR TITLE
Refresh random room task list

### DIFF
--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -1,24 +1,25 @@
 import streamlit as st
 import json
 import os
-from difflib import SequenceMatcher
+
+from dotenv import load_dotenv
+
+from api import client, SYSTEM_PROMPT, build_bootstrap_user_message
+from jsonl import predict_with_model, save_experiment_1_result
 from move_functions import (
     move_to,
     pick_object,
     place_object_next_to,
     place_object_on,
 )
-from dotenv import load_dotenv
-from api import client, SYSTEM_PROMPT, build_bootstrap_user_message
-from strips import strip_tags, extract_between
 from run_and_show import (
-    show_function_sequence,
-    show_clarifying_question,
     run_plan_and_show,
+    show_clarifying_question,
+    show_function_sequence,
 )
-from jsonl import predict_with_model, save_experiment_1_result
 from run_and_show import show_provisional_output
-from pathlib import Path
+from strips import extract_between, strip_tags
+from tasks.ui import render_random_room_task
 
 load_dotenv()
 
@@ -117,6 +118,9 @@ def app():
             image_dir = os.path.join(image_dir, st.session_state["selected_subfolder"])
     else:
         st.session_state["selected_subfolder"] = ""
+
+    selected_room = st.session_state.get("selected_subfolder", "")
+    render_random_room_task(selected_room, state_prefix="experiment1")
 
     if os.path.isdir(image_dir):
         image_files = [

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -1,20 +1,22 @@
-import streamlit as st
-import re
 import json
 import os
+import re
+
 import joblib
-from move_functions import move_to, pick_object, place_object_next_to, place_object_on
-from openai import OpenAI
+import streamlit as st
 from dotenv import load_dotenv
+
 from api import (
-    client,
-    SYSTEM_PROMPT_STANDARD,
     SYSTEM_PROMPT_FRIENDLY,
     SYSTEM_PROMPT_PRATFALL,
+    SYSTEM_PROMPT_STANDARD,
     build_bootstrap_user_message,
+    client,
 )
 from jsonl import predict_with_model, save_experiment_2_result
-from run_and_show import show_function_sequence, show_clarifying_question, run_plan_and_show
+from move_functions import move_to, pick_object, place_object_next_to, place_object_on
+from run_and_show import run_plan_and_show, show_clarifying_question, show_function_sequence
+from tasks.ui import render_random_room_task
 from two_classify import prepare_data  # 既存関数を利用
 
 load_dotenv()
@@ -181,6 +183,9 @@ def app():
             image_dir = os.path.join(image_dir, st.session_state["selected_subfolder"])
     else:
         st.session_state["selected_subfolder"] = ""
+
+    selected_room = st.session_state.get("selected_subfolder", "")
+    render_random_room_task(selected_room, state_prefix="experiment2")
 
     if os.path.isdir(image_dir):
         image_files = [

--- a/pages/pre-experiment.py
+++ b/pages/pre-experiment.py
@@ -2,23 +2,24 @@ import streamlit as st
 import json
 import os
 from difflib import SequenceMatcher
+from dotenv import load_dotenv
+
+from api import client, SYSTEM_PROMPT, build_bootstrap_user_message
+from jsonl import predict_with_model, save_pre_experiment_result
 from move_functions import (
     move_to,
     pick_object,
     place_object_next_to,
     place_object_on,
 )
-from dotenv import load_dotenv
-from api import client, SYSTEM_PROMPT, build_bootstrap_user_message
-from strips import strip_tags, extract_between
 from run_and_show import (
-    show_function_sequence,
-    show_clarifying_question,
     run_plan_and_show,
+    show_clarifying_question,
+    show_function_sequence,
 )
-from jsonl import predict_with_model, save_pre_experiment_result
 from run_and_show import show_provisional_output
-from pathlib import Path
+from strips import extract_between, strip_tags
+from tasks.ui import render_random_room_task
 
 load_dotenv()
 
@@ -176,6 +177,9 @@ def app():
             image_dir = os.path.join(image_dir, st.session_state["selected_subfolder"])
     else:
         st.session_state["selected_subfolder"] = ""
+
+    selected_room = st.session_state.get("selected_subfolder", "")
+    render_random_room_task(selected_room, state_prefix="pre_experiment")
 
     if os.path.isdir(image_dir):
         image_files = [

--- a/pages/save_data.py
+++ b/pages/save_data.py
@@ -1,18 +1,19 @@
-import streamlit as st
 import json
 import os
 import re
-from openai import OpenAI
+
+import streamlit as st
 from dotenv import load_dotenv
+
 from api import client, build_bootstrap_user_message, CREATING_DATA_SYSTEM_PROMPT
-from move_functions import move_to, pick_object, place_object_next_to, place_object_on
-from run_and_show import show_function_sequence, show_clarifying_question, show_information, run_plan_and_show
 from jsonl import (
+    remove_last_jsonl_entry,
     save_jsonl_entry,
     show_jsonl_block,
-    save_pre_experiment_result,
-    remove_last_jsonl_entry,
 )
+from move_functions import move_to, pick_object, place_object_next_to, place_object_on
+from run_and_show import run_plan_and_show, show_clarifying_question, show_function_sequence, show_information
+from tasks.ui import render_random_room_task
 
 load_dotenv()
 
@@ -98,6 +99,9 @@ def app():
             image_dir = os.path.join(image_dir, st.session_state["selected_subfolder"])
     else:
         st.session_state["selected_subfolder"] = ""
+
+    selected_room = st.session_state.get("selected_subfolder", "")
+    render_random_room_task(selected_room, state_prefix="save_data")
 
     if os.path.isdir(image_dir):
         image_files = [

--- a/tasks/tasks.py
+++ b/tasks/tasks.py
@@ -1,17 +1,18 @@
-from typing import Dict, List
+import random
+from typing import Dict, List, Optional
 
-DEFAULT_ROOM_TASKS: Dict[str, List[str]] = {
+BASE_ROOM_TASKS: Dict[str, List[str]] = {
     "リビング": [
-        "リビングのあの電気をつけて",
-        "ソファの横のランプをつけて",
+        "リビングのカーテンを開けて",
+        "ソファのクッションを整えて",
+        "テレビのリモコンを探して",
         "『そこ』のライトを消す",
         "『こっち』の扇風機をつける",
-        "扇風機を首振りにして",
         "テーブルの上の紙を渡して",
         "『近く』のティッシュを渡して",
-        "『あのリモコン』を探して",
-        "ソファの下にある小物を拾って",
         "ダイニングの椅子の上の本を運んで",
+        "観葉植物に水をあげて",
+        "リビングの電気を少し暗くして",
     ],
     "寝室": [
         "ベッドわきのライトを消す",
@@ -20,10 +21,14 @@ DEFAULT_ROOM_TASKS: Dict[str, List[str]] = {
         "寝室の椅子にある服を運んで",
         "『ここ』にある靴下を片付けて",
         "寝室の机の上の本を取ってきて",
+        "ベッドメイキングをして",
+        "枕をふわっと整えて",
     ],
     "廊下": [
         "廊下の明かりを消して",
         "廊下のゴミを拾って",
+        "廊下に落ちている靴をそろえて",
+        "廊下のランナーをまっすぐに直して",
     ],
     "キッチン": [
         "台所の電気を少し暗くして",
@@ -32,10 +37,192 @@ DEFAULT_ROOM_TASKS: Dict[str, List[str]] = {
         "シンクの中のフォークを片付けて",
         "コンロの火を止めて",
         "電子レンジを開けて",
+        "食洗機の中を確認して",
+        "シンクのスポンジをすすいで",
+    ],
+    "ダイニング": [
+        "ダイニングのテーブルを拭いて",
+        "テーブルの上の食器を下げて",
+        "ダイニングの椅子をきれいに並べて",
+        "テーブルにランチョンマットを敷いて",
+        "ペンダントライトの明かりを調整して",
     ],
     "玄関": [
         "玄関の鍵を閉めて",
         "玄関の近くにある雑誌を運んで",
         "玄関の靴を整えて",
-        ],
+        "玄関マットのほこりを払って",
+        "傘立ての傘をそろえて",
+    ],
+    "洗面所": [
+        "洗面台の鏡を軽く拭いて",
+        "洗面台のコップを洗って",
+        "タオルを新しいものに交換して",
+        "洗面台のライトを点けて",
+        "洗濯かごの周りを整えて",
+    ],
+    "浴室": [
+        "バスタブの栓が閉まっているか確認して",
+        "浴室の換気扇をつけて",
+        "シャンプーボトルをそろえて",
+        "浴槽のふたを閉めて",
+        "バスマットを干して",
+    ],
+    "トイレ": [
+        "トイレットペーパーの残量を確認して",
+        "トイレの換気扇をつけて",
+        "トイレマットを整えて",
+        "手洗い場のタオルを交換して",
+    ],
+    "クローゼット": [
+        "クローゼットの照明をつけて",
+        "クローゼットのハンガーを整えて",
+        "クローゼットの床に置かれた箱を片付けて",
+        "収納ケースを引き出して中を確認して",
+    ],
+    "階段": [
+        "階段の電気をつけて",
+        "階段の手すりを軽く拭いて",
+        "階段の途中にある荷物を片付けて",
+        "階段下の収納を確認して",
+    ],
+    "子供部屋": [
+        "子供部屋のおもちゃを片付けて",
+        "子供部屋の照明をつけて",
+        "本棚の絵本をそろえて",
+        "学習机の上を整えて",
+    ],
+    "ガレージ": [
+        "ガレージのライトを消して",
+        "自転車を所定の位置に戻して",
+        "工具が散らかっていないか確認して",
+        "シャッターが閉まっているか見てきて",
+    ],
+    "納屋": [
+        "納屋の窓を開けて換気して",
+        "納屋の棚に置かれた道具を整えて",
+        "納屋のライトをつけて",
+        "納屋の床に落ちているものを拾って",
+    ],
+    "予備室": [
+        "部屋のカーテンを開けて",
+        "部屋のライトをつけて",
+        "机の上のノートをそろえて",
+        "部屋の椅子を元の位置に戻して",
+    ],
 }
+
+ROOM_ALIASES: Dict[str, str] = {
+    "リビング": "リビング",
+    "LIVING": "リビング",
+    "LIVINGROOM": "リビング",
+    "LIVING ROOM": "リビング",
+    "ROOM": "リビング",
+    "寝室": "寝室",
+    "BEDROOM": "寝室",
+    "キッチン": "キッチン",
+    "KITCHEN": "キッチン",
+    "ダイニング": "ダイニング",
+    "DINING": "ダイニング",
+    "DININGROOM": "ダイニング",
+    "DINING ROOM": "ダイニング",
+    "廊下": "廊下",
+    "HALL": "廊下",
+    "HALLWAY": "廊下",
+    "階段": "階段",
+    "STAIRS": "階段",
+    "玄関": "玄関",
+    "ENTRANCE": "玄関",
+    "DOORWAY": "玄関",
+    "洗面所": "洗面所",
+    "WASHROOM": "洗面所",
+    "浴室": "浴室",
+    "BATHROOM": "浴室",
+    "トイレ": "トイレ",
+    "TOILET": "トイレ",
+    "クローゼット": "クローゼット",
+    "CLOSET": "クローゼット",
+    "子供部屋": "子供部屋",
+    "KIDSROOM": "子供部屋",
+    "ガレージ": "ガレージ",
+    "GARAGE": "ガレージ",
+    "納屋": "納屋",
+    "BARN": "納屋",
+    "ROOM1": "予備室",
+    "ROOM2": "予備室",
+    "ROOM3": "予備室",
+    "ROOM4": "予備室",
+    "ROOM5": "予備室",
+}
+
+DEFAULT_ROOM_TASKS: Dict[str, List[str]] = {
+    alias: BASE_ROOM_TASKS[base]
+    for alias, base in ROOM_ALIASES.items()
+    if base in BASE_ROOM_TASKS
+}
+
+
+def get_tasks_for_room(
+    room_name: str,
+    tasks_map: Optional[Dict[str, List[str]]] = None,
+) -> List[str]:
+    """Return the list of tasks associated with the given room name.
+
+    Args:
+        room_name: The room identifier selected in the UI. Both Japanese labels
+            and room directory names (e.g. ``LIVINGROOM``) are supported.
+        tasks_map: Optional mapping that overrides the default task list.
+
+    Returns:
+        A list of task strings. Empty when no tasks are registered for the room.
+    """
+
+    if not room_name:
+        return []
+
+    mapping = tasks_map or DEFAULT_ROOM_TASKS
+    normalized = room_name.strip()
+    if not normalized:
+        return []
+
+    if normalized in mapping:
+        return mapping[normalized]
+
+    normalized_upper = normalized.upper()
+    if normalized_upper in mapping:
+        return mapping[normalized_upper]
+
+    for alias in sorted(ROOM_ALIASES, key=len, reverse=True):
+        alias_upper = alias.upper()
+        if alias_upper and alias_upper in normalized_upper:
+            base = ROOM_ALIASES[alias]
+            tasks = (
+                mapping.get(alias)
+                or mapping.get(alias_upper)
+                or mapping.get(base)
+                or BASE_ROOM_TASKS.get(base, [])
+            )
+            if tasks:
+                return tasks
+
+    return []
+
+
+def choose_random_task(
+    room_name: str,
+    tasks_map: Optional[Dict[str, List[str]]] = None,
+) -> Optional[str]:
+    """Pick a random task for the specified room.
+
+    Args:
+        room_name: The room identifier selected in the UI.
+        tasks_map: Optional mapping that overrides the default task list.
+
+    Returns:
+        A randomly chosen task string, or ``None`` when no tasks are available.
+    """
+
+    tasks = get_tasks_for_room(room_name, tasks_map)
+    if not tasks:
+        return None
+    return random.choice(tasks)

--- a/tasks/ui.py
+++ b/tasks/ui.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from .tasks import choose_random_task, get_tasks_for_room
+
+
+def render_random_room_task(
+    room_name: str,
+    state_prefix: str,
+    *,
+    title: str = "本日のタスク例",
+    reroll_label: str = "🔀 他のタスクを表示",
+) -> str | None:
+    """Display a random task for the specified room at the top of the page.
+
+    Args:
+        room_name: Room identifier chosen in the UI. Empty string means no selection.
+        state_prefix: Prefix used to keep Streamlit session state keys unique per page.
+        title: Heading shown above the task suggestion.
+        reroll_label: Label for the button to pick another random task.
+
+    Returns:
+        The currently displayed random task or ``None`` when there is nothing to show.
+    """
+
+    task_state_key = f"{state_prefix}_random_task"
+    room_state_key = f"{state_prefix}_task_room"
+
+    if st.session_state.get(room_state_key) != room_name:
+        st.session_state[room_state_key] = room_name
+        st.session_state[task_state_key] = choose_random_task(room_name)
+
+    st.markdown(f"### {title}")
+
+    if not room_name:
+        st.info("部屋を選択すると、タスク候補が表示されます。")
+        st.session_state[task_state_key] = None
+        return None
+
+    tasks = get_tasks_for_room(room_name)
+    if not tasks:
+        st.info(f"部屋「{room_name}」に対応するタスク候補は未登録です。")
+        st.session_state[task_state_key] = None
+        return None
+
+    if st.button(reroll_label, key=f"{state_prefix}_reroll"):
+        st.session_state[task_state_key] = choose_random_task(room_name)
+
+    task = st.session_state.get(task_state_key)
+    if task:
+        st.success(f"部屋「{room_name}」のタスク例：{task}")
+    return task


### PR DESCRIPTION
## Summary
- expand the base Japanese task prompts and add coverage for dining, washroom, bathroom, toilet, closet, stairs, kids room, garage, barn, and spare rooms
- map new room directory names to the refreshed prompts so reroll banners display suggestions for every updated room

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d35d4733148320b9fbefd9422fd920