### PR TITLE
Fix missing os import in jsonl

### DIFF
--- a/jsonl.py
+++ b/jsonl.py
@@ -1,9 +1,11 @@
-import streamlit as st
 import json
+import os
 import re
-from pathlib import Path
-import joblib
 from itertools import zip_longest
+from pathlib import Path
+
+import joblib
+import streamlit as st
 
 from typing import Any, List, Optional, Tuple
 from dotenv import load_dotenv


### PR DESCRIPTION
## Summary
- import the os module in jsonl.py to support existing environment variable usage
- tidy the import block grouping standard and third-party packages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4526cf75c8320adf327c20c23bd62