### PR TITLE
Support Firestore credentials file option

### DIFF
--- a/firebase_utils.py
+++ b/firebase_utils.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 import firebase_admin
 from firebase_admin import credentials, firestore
 import streamlit as st
@@ -15,7 +15,21 @@ def _get_db_from_secrets() -> firestore.Client:
         firebase_admin.initialize_app(cred)
     return firestore.client()
 
-def save_document(collection: str, data: Dict[str, Any]) -> None:
-    """Firestoreコレクションにドキュメントを保存（secrets利用）"""
-    db = _get_db_from_secrets()
+
+def _get_db_from_credentials_file(credentials_path: str) -> firestore.Client:
+    """ファイルパスで指定されたサービスアカウント情報からFirestoreへ接続"""
+    if not os.path.exists(credentials_path):
+        raise FileNotFoundError(f"Credentials file not found: {credentials_path}")
+
+    if not firebase_admin._apps:
+        cred = credentials.Certificate(credentials_path)
+        firebase_admin.initialize_app(cred)
+    return firestore.client()
+
+def save_document(collection: str, data: Dict[str, Any], credentials_path: Optional[str] = None) -> None:
+    """Firestoreコレクションにドキュメントを保存"""
+    if credentials_path:
+        db = _get_db_from_credentials_file(credentials_path)
+    else:
+        db = _get_db_from_secrets()
     db.collection(collection).add(data)


### PR DESCRIPTION
## Summary
- allow `firebase_utils.save_document` to accept either Streamlit Cloud secrets or a local service-account file path
- add helper to initialize Firebase from a credentials file and share initialization logic

## Testing
- python -m compileall firebase_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d469a8db708320a5b83618331082b5