### PR TITLE
Add shared image-task set storage and selection

### DIFF
--- a/image_task_sets.py
+++ b/image_task_sets.py
@@ -1,0 +1,66 @@
+"""Utilities for persisting image and task set configurations.
+
+This module centralises the read/write logic so that multiple Streamlit pages
+can share the same storage format.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+_DATA_PATH = Path("json/image_task_sets.json")
+
+
+def load_image_task_sets() -> Dict[str, Dict[str, Any]]:
+    """Load all stored image/task sets.
+
+    Returns an empty dictionary when the storage file does not exist or is
+    malformed. The function is resilient to partial corruption and will ignore
+    entries that are not dictionaries.
+    """
+
+    if not _DATA_PATH.exists():
+        return {}
+
+    try:
+        raw = json.loads(_DATA_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+    if not isinstance(raw, dict):
+        return {}
+
+    cleaned: Dict[str, Dict[str, Any]] = {}
+    for key, value in raw.items():
+        if isinstance(value, dict):
+            cleaned[str(key)] = value
+    return cleaned
+
+
+def save_image_task_sets(task_sets: Dict[str, Dict[str, Any]]) -> None:
+    """Persist the provided task sets to disk."""
+
+    _DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _DATA_PATH.write_text(
+        json.dumps(task_sets, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def upsert_image_task_set(name: str, payload: Dict[str, Any]) -> None:
+    """Create or update a single task set entry."""
+
+    task_sets = load_image_task_sets()
+    task_sets[name] = payload
+    save_image_task_sets(task_sets)
+
+
+def delete_image_task_set(name: str) -> None:
+    """Remove a task set from storage if it exists."""
+
+    task_sets = load_image_task_sets()
+    if name in task_sets:
+        task_sets.pop(name)
+        save_image_task_sets(task_sets)

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -18,7 +18,7 @@ from api import (
 from jsonl import predict_with_model, save_experiment_2_result
 from move_functions import move_to, pick_object, place_object_next_to, place_object_on
 from run_and_show import run_plan_and_show, show_clarifying_question, show_function_sequence
-from tasks.ui import render_random_room_task
+from image_task_sets import load_image_task_sets
 from two_classify import prepare_data  # 既存関数を利用
 
 load_dotenv()
@@ -163,80 +163,70 @@ def app():
         )
         st.session_state["model_path"] = os.path.join("models", selected_model)
 
-    image_root = "images"
-    house_dirs = [d for d in os.listdir(image_root) if os.path.isdir(os.path.join(image_root, d))]
-    default_label = "(default)"
-    options = [default_label] + house_dirs
-    current_house = st.session_state.get("selected_house", "")
-    current_label = current_house if current_house else default_label
-    selected_label = st.selectbox(
-        "想定する家",
-        options,
-        index=options.index(current_label) if current_label in options else 0,
-    )
-    st.session_state["selected_house"] = "" if selected_label == default_label else selected_label
-
-    image_dir = image_root
-    subdirs = []
-    if st.session_state["selected_house"]:
-        image_dir = os.path.join(image_dir, st.session_state["selected_house"])
-        subdirs = [d for d in os.listdir(image_dir) if os.path.isdir(os.path.join(image_dir, d))]
-    sub_default = "(default)"
-    if subdirs:
-        current_sub = st.session_state.get("selected_subfolder", "")
-        current_sub_label = current_sub if current_sub else sub_default
-        sub_options = [sub_default] + subdirs
-        sub_label = st.selectbox(
-            "部屋",
-            sub_options,
-            index=sub_options.index(current_sub_label) if current_sub_label in sub_options else 0,
-        )
-        st.session_state["selected_subfolder"] = "" if sub_label == sub_default else sub_label
-        if st.session_state["selected_subfolder"]:
-            image_dir = os.path.join(image_dir, st.session_state["selected_subfolder"])
-    else:
-        st.session_state["selected_subfolder"] = ""
-
-    if os.path.isdir(image_dir):
-        image_files = [
-            f
-            for f in os.listdir(image_dir)
-            if os.path.isfile(os.path.join(image_dir, f))
-            and f.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp"))
-        ]
-        if image_files:
-            selected_imgs = st.multiselect("表示する画像", image_files)
-            selected_paths = [os.path.join(image_dir, img) for img in selected_imgs]
-            st.session_state["selected_image_paths"] = selected_paths
-            for path, img in zip(selected_paths, selected_imgs):
-                st.image(path, caption=img)
-        else:
-            st.session_state["selected_image_paths"] = []
-    else:
+    task_sets = load_image_task_sets()
+    if not task_sets:
+        st.warning("写真とタスクのセットが保存されていません。まず『写真とタスクの選定・保存』ページで作成してください。")
         st.session_state["selected_image_paths"] = []
+        st.session_state["experiment2_selected_task_set"] = None
+    else:
+        task_names = sorted(task_sets.keys())
+        default_task = st.session_state.get("experiment2_selected_task_set")
+        if default_task not in task_names:
+            default_task = task_names[0]
+        selected_task_name = st.selectbox(
+            "タスクセット",
+            task_names,
+            index=task_names.index(default_task) if default_task in task_names else 0,
+        )
+        st.session_state["experiment2_selected_task_set"] = selected_task_name
+        payload = task_sets.get(selected_task_name, {})
+        house = payload.get("house") if isinstance(payload, dict) else ""
+        room = payload.get("room") if isinstance(payload, dict) else ""
+        meta_lines = []
+        if house:
+            meta_lines.append(f"想定する家: {house}")
+        if room:
+            meta_lines.append(f"部屋: {room}")
+        if meta_lines:
+            st.info(" / ".join(meta_lines))
 
-    def _infer_room_from_image_name(image_name: str) -> str | None:
-        base = os.path.splitext(os.path.basename(image_name))[0]
-        cleaned = re.sub(r"[^0-9A-Za-zぁ-んァ-ン一-龠ー]+", " ", base).strip()
-        cleaned = re.sub(r"\s+", " ", cleaned)
-        if not cleaned:
-            return None
-        if all(ord(ch) < 128 for ch in cleaned):
-            return cleaned.upper()
-        return cleaned
+        task_lines = []
+        if isinstance(payload, dict):
+            tasks_value = payload.get("tasks")
+            if isinstance(tasks_value, list):
+                task_lines = [str(t) for t in tasks_value if str(t).strip()]
+            elif isinstance(tasks_value, str):
+                task_lines = [line.strip() for line in tasks_value.splitlines() if line.strip()]
+            else:
+                raw_text = payload.get("task_text")
+                if isinstance(raw_text, str):
+                    task_lines = [line.strip() for line in raw_text.splitlines() if line.strip()]
 
-    inferred_room = ""
-    if st.session_state.get("selected_subfolder"):
-        inferred_room = st.session_state["selected_subfolder"]
-    elif st.session_state.get("selected_image_paths"):
-        for img_path in st.session_state["selected_image_paths"]:
-            candidate = _infer_room_from_image_name(os.path.basename(img_path))
-            if candidate:
-                inferred_room = candidate
-                break
+        st.markdown("### タスク")
+        if task_lines:
+            for line in task_lines:
+                st.write(f"- {line}")
+        else:
+            st.info("タスクが登録されていません。")
 
-    st.session_state["experiment2_inferred_room"] = inferred_room
-    render_random_room_task(inferred_room, state_prefix="experiment2")
+        image_candidates = []
+        if isinstance(payload, dict):
+            image_candidates = [str(p) for p in payload.get("images", []) if isinstance(p, str)]
+
+        existing_images = [p for p in image_candidates if os.path.exists(p)]
+        missing_images = [p for p in image_candidates if p not in existing_images]
+
+        st.session_state["selected_image_paths"] = existing_images
+
+        if missing_images:
+            st.warning("以下の画像ファイルが見つかりません: " + ", ".join(missing_images))
+
+        st.markdown("### 選択された画像")
+        if existing_images:
+            for path in existing_images:
+                st.image(path, caption=os.path.basename(path))
+        else:
+            st.info("画像が設定されていません。")
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if (


### PR DESCRIPTION
## Summary
- add a shared helper for persisting task/image sets to `json/image_task_sets.json`
- rebuild the image selection page so task/image sets can be created, edited, or deleted and listed from storage
- update experiment pages to load saved sets via a selectbox and present the associated tasks and images

## Testing
- python -m compileall image_task_sets.py pages/images_and_tasks.py pages/experiment_1.py pages/experiment_2.py

------
https://chatgpt.com/codex/tasks/task_e_68d49978e1b48320a3b244a2e7ca91e2