### PR TITLE
Use task content as task set identifier

### DIFF
--- a/image_task_sets.py
+++ b/image_task_sets.py
@@ -1,0 +1,116 @@
+"""Utilities for persisting image and task set configurations.
+
+This module centralises the read/write logic so that multiple Streamlit pages
+can share the same storage format.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+_DATA_PATH = Path("json/image_task_sets.json")
+
+
+def load_image_task_sets() -> Dict[str, Dict[str, Any]]:
+    """Load all stored image/task sets.
+
+    Returns an empty dictionary when the storage file does not exist or is
+    malformed. The function is resilient to partial corruption and will ignore
+    entries that are not dictionaries.
+    """
+
+    if not _DATA_PATH.exists():
+        return {}
+
+    try:
+        raw = json.loads(_DATA_PATH.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+    if not isinstance(raw, dict):
+        return {}
+
+    cleaned: Dict[str, Dict[str, Any]] = {}
+    for key, value in raw.items():
+        if isinstance(value, dict):
+            cleaned[str(key)] = value
+    return cleaned
+
+
+def save_image_task_sets(task_sets: Dict[str, Dict[str, Any]]) -> None:
+    """Persist the provided task sets to disk."""
+
+    _DATA_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _DATA_PATH.write_text(
+        json.dumps(task_sets, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
+def upsert_image_task_set(name: str, payload: Dict[str, Any]) -> None:
+    """Create or update a single task set entry."""
+
+    task_sets = load_image_task_sets()
+    task_sets[name] = payload
+    save_image_task_sets(task_sets)
+
+
+def delete_image_task_set(name: str) -> None:
+    """Remove a task set from storage if it exists."""
+
+    task_sets = load_image_task_sets()
+    if name in task_sets:
+        task_sets.pop(name)
+        save_image_task_sets(task_sets)
+
+
+def extract_task_lines(payload: Dict[str, Any]) -> List[str]:
+    """Return a list of task strings from a payload."""
+
+    tasks: List[str] = []
+    if not isinstance(payload, dict):
+        return tasks
+
+    value = payload.get("tasks")
+    if isinstance(value, list):
+        tasks = [str(item).strip() for item in value if str(item).strip()]
+    elif isinstance(value, str):
+        tasks = [line.strip() for line in value.splitlines() if line.strip()]
+    else:
+        raw_text = payload.get("task_text")
+        if isinstance(raw_text, str):
+            tasks = [line.strip() for line in raw_text.splitlines() if line.strip()]
+    return tasks
+
+
+def derive_task_set_label(name: str, payload: Dict[str, Any]) -> str:
+    """Create a human-readable label for a stored task set."""
+
+    task_lines = extract_task_lines(payload)
+    if task_lines:
+        label = task_lines[0]
+    else:
+        label = name.strip()
+
+    label = label.replace("\n", " / ").strip()
+    return label or "(タスク未設定)"
+
+
+def build_task_set_choices(
+    task_sets: Dict[str, Dict[str, Any]]
+) -> List[Tuple[str, str]]:
+    """Return (label, key) tuples for select boxes."""
+
+    choices: List[Tuple[str, str]] = []
+    counts: Dict[str, int] = {}
+    for key, payload in task_sets.items():
+        base_label = derive_task_set_label(key, payload)
+        counts[base_label] = counts.get(base_label, 0) + 1
+        suffix = "" if counts[base_label] == 1 else f" ({counts[base_label]})"
+        display_label = f"{base_label}{suffix}"
+        choices.append((display_label, key))
+
+    choices.sort(key=lambda item: item[0])
+    return choices

--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -19,7 +19,11 @@ from run_and_show import (
 )
 from run_and_show import show_provisional_output
 from strips import extract_between, strip_tags
-from tasks.ui import render_random_room_task
+from image_task_sets import (
+    build_task_set_choices,
+    extract_task_lines,
+    load_image_task_sets,
+)
 
 load_dotenv()
 
@@ -85,58 +89,76 @@ def app():
         )
         st.session_state["model_path"] = os.path.join("models", selected_model)
 
-    image_root = "images"
-    house_dirs = [d for d in os.listdir(image_root) if os.path.isdir(os.path.join(image_root, d))]
-    default_label = "(default)"
-    options = [default_label] + house_dirs
-    current_house = st.session_state.get("selected_house", "")
-    current_label = current_house if current_house else default_label
-    selected_label = st.selectbox(
-        "想定する家",
-        options,
-        index=options.index(current_label) if current_label in options else 0,
-    )
-    st.session_state["selected_house"] = "" if selected_label == default_label else selected_label
-
-    image_dir = image_root
-    subdirs = []
-    if st.session_state["selected_house"]:
-        image_dir = os.path.join(image_dir, st.session_state["selected_house"])
-        subdirs = [d for d in os.listdir(image_dir) if os.path.isdir(os.path.join(image_dir, d))]
-    sub_default = "(default)"
-    if subdirs:
-        current_sub = st.session_state.get("selected_subfolder", "")
-        current_sub_label = current_sub if current_sub else sub_default
-        sub_options = [sub_default] + subdirs
-        sub_label = st.selectbox(
-            "部屋",
-            sub_options,
-            index=sub_options.index(current_sub_label) if current_sub_label in sub_options else 0,
-        )
-        st.session_state["selected_subfolder"] = "" if sub_label == sub_default else sub_label
-        if st.session_state["selected_subfolder"]:
-            image_dir = os.path.join(image_dir, st.session_state["selected_subfolder"])
+    task_sets = load_image_task_sets()
+    if not task_sets:
+        st.warning("写真とタスクのセットが保存されていません。まず『写真とタスクの選定・保存』ページで作成してください。")
+        st.session_state["selected_image_paths"] = []
+        st.session_state["experiment1_selected_task_set"] = None
     else:
-        st.session_state["selected_subfolder"] = ""
+        choice_pairs = build_task_set_choices(task_sets)
+        labels = [label for label, _ in choice_pairs]
+        label_to_key = {label: key for label, key in choice_pairs}
 
-    selected_room = st.session_state.get("selected_subfolder", "")
-    render_random_room_task(selected_room, state_prefix="experiment1")
-
-    if os.path.isdir(image_dir):
-        image_files = [
-            f
-            for f in os.listdir(image_dir)
-            if os.path.isfile(os.path.join(image_dir, f))
-            and f.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp"))
-        ]
-        if image_files:
-            selected_imgs = st.multiselect("表示する画像", image_files)
-            selected_paths = [os.path.join(image_dir, img) for img in selected_imgs]
-            st.session_state["selected_image_paths"] = selected_paths
-            for path, img in zip(selected_paths, selected_imgs):
-                st.image(path, caption=img)
-        else:
+        if not labels:
+            st.warning("保存済みのタスクが読み込めませんでした。")
             st.session_state["selected_image_paths"] = []
+            st.session_state["experiment1_selected_task_set"] = None
+            payload = {}
+        else:
+            default_key = st.session_state.get("experiment1_selected_task_set")
+            if default_key not in label_to_key.values():
+                default_key = choice_pairs[0][1]
+
+            default_label = next(
+                (label for label, key in choice_pairs if key == default_key),
+                labels[0],
+            )
+
+            selected_label = st.selectbox(
+                "タスク",
+                labels,
+                index=labels.index(default_label) if default_label in labels else 0,
+            )
+            selected_task_name = label_to_key.get(selected_label)
+            st.session_state["experiment1_selected_task_set"] = selected_task_name
+            payload = task_sets.get(selected_task_name, {}) if selected_task_name else {}
+        house = payload.get("house") if isinstance(payload, dict) else ""
+        room = payload.get("room") if isinstance(payload, dict) else ""
+        meta_lines = []
+        if house:
+            meta_lines.append(f"想定する家: {house}")
+        if room:
+            meta_lines.append(f"部屋: {room}")
+        if meta_lines:
+            st.info(" / ".join(meta_lines))
+
+        task_lines = extract_task_lines(payload)
+
+        st.markdown("### タスク")
+        if task_lines:
+            for line in task_lines:
+                st.write(f"- {line}")
+        else:
+            st.info("タスクが登録されていません。")
+
+        image_candidates = []
+        if isinstance(payload, dict):
+            image_candidates = [str(p) for p in payload.get("images", []) if isinstance(p, str)]
+
+        existing_images = [p for p in image_candidates if os.path.exists(p)]
+        missing_images = [p for p in image_candidates if p not in existing_images]
+
+        st.session_state["selected_image_paths"] = existing_images
+
+        if missing_images:
+            st.warning("以下の画像ファイルが見つかりません: " + ", ".join(missing_images))
+
+        st.markdown("### 選択された画像")
+        if existing_images:
+            for path in existing_images:
+                st.image(path, caption=os.path.basename(path))
+        else:
+            st.info("画像が設定されていません。")
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if (

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -18,7 +18,11 @@ from api import (
 from jsonl import predict_with_model, save_experiment_2_result
 from move_functions import move_to, pick_object, place_object_next_to, place_object_on
 from run_and_show import run_plan_and_show, show_clarifying_question, show_function_sequence
-from tasks.ui import render_random_room_task
+from image_task_sets import (
+    build_task_set_choices,
+    extract_task_lines,
+    load_image_task_sets,
+)
 from two_classify import prepare_data  # 既存関数を利用
 
 load_dotenv()
@@ -163,80 +167,76 @@ def app():
         )
         st.session_state["model_path"] = os.path.join("models", selected_model)
 
-    image_root = "images"
-    house_dirs = [d for d in os.listdir(image_root) if os.path.isdir(os.path.join(image_root, d))]
-    default_label = "(default)"
-    options = [default_label] + house_dirs
-    current_house = st.session_state.get("selected_house", "")
-    current_label = current_house if current_house else default_label
-    selected_label = st.selectbox(
-        "想定する家",
-        options,
-        index=options.index(current_label) if current_label in options else 0,
-    )
-    st.session_state["selected_house"] = "" if selected_label == default_label else selected_label
-
-    image_dir = image_root
-    subdirs = []
-    if st.session_state["selected_house"]:
-        image_dir = os.path.join(image_dir, st.session_state["selected_house"])
-        subdirs = [d for d in os.listdir(image_dir) if os.path.isdir(os.path.join(image_dir, d))]
-    sub_default = "(default)"
-    if subdirs:
-        current_sub = st.session_state.get("selected_subfolder", "")
-        current_sub_label = current_sub if current_sub else sub_default
-        sub_options = [sub_default] + subdirs
-        sub_label = st.selectbox(
-            "部屋",
-            sub_options,
-            index=sub_options.index(current_sub_label) if current_sub_label in sub_options else 0,
-        )
-        st.session_state["selected_subfolder"] = "" if sub_label == sub_default else sub_label
-        if st.session_state["selected_subfolder"]:
-            image_dir = os.path.join(image_dir, st.session_state["selected_subfolder"])
-    else:
-        st.session_state["selected_subfolder"] = ""
-
-    if os.path.isdir(image_dir):
-        image_files = [
-            f
-            for f in os.listdir(image_dir)
-            if os.path.isfile(os.path.join(image_dir, f))
-            and f.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp"))
-        ]
-        if image_files:
-            selected_imgs = st.multiselect("表示する画像", image_files)
-            selected_paths = [os.path.join(image_dir, img) for img in selected_imgs]
-            st.session_state["selected_image_paths"] = selected_paths
-            for path, img in zip(selected_paths, selected_imgs):
-                st.image(path, caption=img)
-        else:
-            st.session_state["selected_image_paths"] = []
-    else:
+    task_sets = load_image_task_sets()
+    if not task_sets:
+        st.warning("写真とタスクのセットが保存されていません。まず『写真とタスクの選定・保存』ページで作成してください。")
         st.session_state["selected_image_paths"] = []
+        st.session_state["experiment2_selected_task_set"] = None
+    else:
+        choice_pairs = build_task_set_choices(task_sets)
+        labels = [label for label, _ in choice_pairs]
+        label_to_key = {label: key for label, key in choice_pairs}
 
-    def _infer_room_from_image_name(image_name: str) -> str | None:
-        base = os.path.splitext(os.path.basename(image_name))[0]
-        cleaned = re.sub(r"[^0-9A-Za-zぁ-んァ-ン一-龠ー]+", " ", base).strip()
-        cleaned = re.sub(r"\s+", " ", cleaned)
-        if not cleaned:
-            return None
-        if all(ord(ch) < 128 for ch in cleaned):
-            return cleaned.upper()
-        return cleaned
+        if not labels:
+            st.warning("保存済みのタスクが読み込めませんでした。")
+            st.session_state["selected_image_paths"] = []
+            st.session_state["experiment2_selected_task_set"] = None
+            payload = {}
+        else:
+            default_key = st.session_state.get("experiment2_selected_task_set")
+            if default_key not in label_to_key.values():
+                default_key = choice_pairs[0][1]
 
-    inferred_room = ""
-    if st.session_state.get("selected_subfolder"):
-        inferred_room = st.session_state["selected_subfolder"]
-    elif st.session_state.get("selected_image_paths"):
-        for img_path in st.session_state["selected_image_paths"]:
-            candidate = _infer_room_from_image_name(os.path.basename(img_path))
-            if candidate:
-                inferred_room = candidate
-                break
+            default_label = next(
+                (label for label, key in choice_pairs if key == default_key),
+                labels[0],
+            )
 
-    st.session_state["experiment2_inferred_room"] = inferred_room
-    render_random_room_task(inferred_room, state_prefix="experiment2")
+            selected_label = st.selectbox(
+                "タスク",
+                labels,
+                index=labels.index(default_label) if default_label in labels else 0,
+            )
+            selected_task_name = label_to_key.get(selected_label)
+            st.session_state["experiment2_selected_task_set"] = selected_task_name
+            payload = task_sets.get(selected_task_name, {}) if selected_task_name else {}
+        house = payload.get("house") if isinstance(payload, dict) else ""
+        room = payload.get("room") if isinstance(payload, dict) else ""
+        meta_lines = []
+        if house:
+            meta_lines.append(f"想定する家: {house}")
+        if room:
+            meta_lines.append(f"部屋: {room}")
+        if meta_lines:
+            st.info(" / ".join(meta_lines))
+
+        task_lines = extract_task_lines(payload)
+
+        st.markdown("### タスク")
+        if task_lines:
+            for line in task_lines:
+                st.write(f"- {line}")
+        else:
+            st.info("タスクが登録されていません。")
+
+        image_candidates = []
+        if isinstance(payload, dict):
+            image_candidates = [str(p) for p in payload.get("images", []) if isinstance(p, str)]
+
+        existing_images = [p for p in image_candidates if os.path.exists(p)]
+        missing_images = [p for p in image_candidates if p not in existing_images]
+
+        st.session_state["selected_image_paths"] = existing_images
+
+        if missing_images:
+            st.warning("以下の画像ファイルが見つかりません: " + ", ".join(missing_images))
+
+        st.markdown("### 選択された画像")
+        if existing_images:
+            for path in existing_images:
+                st.image(path, caption=os.path.basename(path))
+        else:
+            st.info("画像が設定されていません。")
 
     # 1) セッションにコンテキストを初期化（systemだけ先に入れて保持）
     if (

--- a/pages/images_and_tasks.py
+++ b/pages/images_and_tasks.py
@@ -1,115 +1,281 @@
-import streamlit as st
-import json
 import os
+from pathlib import Path
+from typing import Dict, List
 
+import streamlit as st
 from dotenv import load_dotenv
 
-from api import client, SYSTEM_PROMPT, build_bootstrap_user_message
-from jsonl import predict_with_model, save_experiment_1_result
-from move_functions import (
-    move_to,
-    pick_object,
-    place_object_next_to,
-    place_object_on,
+from image_task_sets import (
+    build_task_set_choices,
+    delete_image_task_set,
+    load_image_task_sets,
+    upsert_image_task_set,
 )
-from run_and_show import (
-    run_plan_and_show,
-    show_clarifying_question,
-    show_function_sequence,
-)
-from run_and_show import show_provisional_output
-from strips import extract_between, strip_tags
-from tasks.ui import render_random_room_task
 
 load_dotenv()
 
+IMAGE_ROOT = Path("images")
+NEW_SET_LABEL = "(新規作成)"
+DEFAULT_LABEL = "(default)"
+
+
+def _ensure_form_state() -> None:
+    defaults: Dict[str, str | List[str]] = {
+        "task_description": "",
+        "selected_house": "",
+        "selected_subfolder": "",
+    }
+    for key, value in defaults.items():
+        st.session_state.setdefault(key, value)
+    st.session_state.setdefault("selected_image_paths", [])
+    st.session_state.setdefault("current_task_set_choice", NEW_SET_LABEL)
+
+
+def _reset_form_state() -> None:
+    st.session_state.update(
+        {
+            "task_description": "",
+            "selected_house": "",
+            "selected_subfolder": "",
+            "selected_image_paths": [],
+            "current_task_set_choice": NEW_SET_LABEL,
+        }
+    )
+
+
+def _populate_form_from_set(name: str, payload: Dict[str, object]) -> None:
+    tasks = payload.get("tasks") if isinstance(payload, dict) else []
+    task_lines: List[str] = []
+    if isinstance(tasks, list):
+        task_lines = [str(t) for t in tasks if str(t).strip()]
+    elif isinstance(tasks, str):
+        task_lines = [line.strip() for line in tasks.splitlines() if line.strip()]
+    elif isinstance(payload, dict):
+        raw_text = payload.get("task_text")
+        if isinstance(raw_text, str):
+            task_lines = [line.strip() for line in raw_text.splitlines() if line.strip()]
+
+    st.session_state.update(
+        {
+            "task_description": "\n".join(task_lines),
+            "selected_house": str(payload.get("house", "")) if isinstance(payload, dict) else "",
+            "selected_subfolder": str(payload.get("room", "")) if isinstance(payload, dict) else "",
+            "selected_image_paths": [
+                str(path) for path in payload.get("images", [])
+            ]
+            if isinstance(payload, dict)
+            else [],
+            "current_task_set_choice": name,
+        }
+    )
+
+
+
 def app():
     st.title("LLMATCH Criticデモアプリ")
-    st.subheader("写真とタスクの選定")
-    
+    st.subheader("写真とタスクの選定・保存")
+
     st.sidebar.subheader("行動計画で使用される関数")
     st.sidebar.markdown(
-    """
-    - **move_to(room_name:str)**  
-    指定した部屋へロボットを移動します。
+        """
+        - **move_to(room_name:str)**
+        指定した部屋へロボットを移動します。
 
-    - **pick_object(object:str)**  
-    指定した物体をつかみます。
+        - **pick_object(object:str)**
+        指定した物体をつかみます。
 
-    - **place_object_next_to(object:str, target:str)**  
-    指定した物体をターゲットの横に置きます。
+        - **place_object_next_to(object:str, target:str)**
+        指定した物体をターゲットの横に置きます。
 
-    - **place_object_on(object:str, target:str)**  
-    指定した物体をターゲットの上に置きます。
+        - **place_object_on(object:str, target:str)**
+        指定した物体をターゲットの上に置きます。
 
-    - **place_object_in(object:str, target:str)**  
-    指定した物体をターゲットの中に入れます。
+        - **place_object_in(object:str, target:str)**
+        指定した物体をターゲットの中に入れます。
 
-    - **detect_object(object:str)**  
-    指定した物体を検出します。
+        - **detect_object(object:str)**
+        指定した物体を検出します。
 
-    - **search_about(object:str)**  
-    指定した物体に関する情報を検索します。
+        - **search_about(object:str)**
+        指定した物体に関する情報を検索します。
 
-    - **push(object:str)**  
-    指定した物体を押します。
+        - **push(object:str)**
+        指定した物体を押します。
 
-    - **say(text:str)**  
-    指定したテキストを発話します。
-    """
+        - **say(text:str)**
+        指定したテキストを発話します。
+        """
     )
 
-    image_root = "images"
-    house_dirs = [d for d in os.listdir(image_root) if os.path.isdir(os.path.join(image_root, d))]
-    default_label = "(default)"
-    options = [default_label] + house_dirs
-    current_house = st.session_state.get("selected_house", "")
-    current_label = current_house if current_house else default_label
+    _ensure_form_state()
+
+    task_sets = load_image_task_sets()
+    choice_pairs = build_task_set_choices(task_sets)
+    labels = [label for label, _ in choice_pairs]
+    label_to_key = {label: key for label, key in choice_pairs}
+
+    selection_options = [NEW_SET_LABEL] + labels
+
+    current_key = st.session_state.get("current_task_set_choice", NEW_SET_LABEL)
+    valid_keys = {key for _, key in choice_pairs}
+    if current_key not in valid_keys and current_key != NEW_SET_LABEL:
+        if current_key in label_to_key:
+            current_key = label_to_key[current_key]
+        else:
+            current_key = NEW_SET_LABEL
+        st.session_state["current_task_set_choice"] = current_key
+    if not labels:
+        default_label = NEW_SET_LABEL
+    elif current_key != NEW_SET_LABEL:
+        default_label = next(
+            (label for label, key in choice_pairs if key == current_key),
+            NEW_SET_LABEL,
+        )
+    else:
+        default_label = NEW_SET_LABEL
+
     selected_label = st.selectbox(
-        "想定する家",
-        options,
-        index=options.index(current_label) if current_label in options else 0,
+        "保存済みのタスク",
+        selection_options,
+        index=selection_options.index(default_label) if default_label in selection_options else 0,
     )
-    st.session_state["selected_house"] = "" if selected_label == default_label else selected_label
 
-    image_dir = image_root
-    subdirs = []
+    selected_key = label_to_key.get(selected_label, NEW_SET_LABEL)
+
+    if selected_key != current_key:
+        if selected_key == NEW_SET_LABEL:
+            _reset_form_state()
+        else:
+            payload = task_sets.get(selected_key, {})
+            _populate_form_from_set(selected_key, payload)
+
+    # --- タスクセット名とタスク内容 ---
+    st.text_area("タスク（1行につき1つの指示を入力してください）", height=120, key="task_description")
+
+    # --- 画像の選択 ---
+    house_dirs = sorted([d for d in os.listdir(IMAGE_ROOT) if (IMAGE_ROOT / d).is_dir()])
+    house_options = [DEFAULT_LABEL] + house_dirs
+    current_house = st.session_state.get("selected_house", "")
+    current_house_label = current_house if current_house else DEFAULT_LABEL
+    house_label = st.selectbox(
+        "想定する家",
+        house_options,
+        index=house_options.index(current_house_label)
+        if current_house_label in house_options
+        else 0,
+    )
+    st.session_state["selected_house"] = "" if house_label == DEFAULT_LABEL else house_label
+
+    image_dir = IMAGE_ROOT
+    subdirs: List[str] = []
     if st.session_state["selected_house"]:
-        image_dir = os.path.join(image_dir, st.session_state["selected_house"])
-        subdirs = [d for d in os.listdir(image_dir) if os.path.isdir(os.path.join(image_dir, d))]
-    sub_default = "(default)"
+        image_dir = image_dir / st.session_state["selected_house"]
+        subdirs = sorted([d for d in os.listdir(image_dir) if (image_dir / d).is_dir()])
+
     if subdirs:
         current_sub = st.session_state.get("selected_subfolder", "")
-        current_sub_label = current_sub if current_sub else sub_default
-        sub_options = [sub_default] + subdirs
+        current_sub_label = current_sub if current_sub else DEFAULT_LABEL
+        sub_options = [DEFAULT_LABEL] + subdirs
         sub_label = st.selectbox(
             "部屋",
             sub_options,
-            index=sub_options.index(current_sub_label) if current_sub_label in sub_options else 0,
+            index=sub_options.index(current_sub_label)
+            if current_sub_label in sub_options
+            else 0,
         )
-        st.session_state["selected_subfolder"] = "" if sub_label == sub_default else sub_label
+        st.session_state["selected_subfolder"] = "" if sub_label == DEFAULT_LABEL else sub_label
         if st.session_state["selected_subfolder"]:
-            image_dir = os.path.join(image_dir, st.session_state["selected_subfolder"])
+            image_dir = image_dir / st.session_state["selected_subfolder"]
     else:
         st.session_state["selected_subfolder"] = ""
 
-    selected_room = st.session_state.get("selected_subfolder", "")
-    render_random_room_task(selected_room, state_prefix="experiment1")
+    selected_paths: List[str] = st.session_state.get("selected_image_paths", [])
+    image_files: List[str] = []
+    if image_dir.is_dir():
+        image_files = sorted(
+            [
+                f
+                for f in os.listdir(image_dir)
+                if (image_dir / f).is_file()
+                and f.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp"))
+            ]
+        )
 
-    if os.path.isdir(image_dir):
-        image_files = [
-            f
-            for f in os.listdir(image_dir)
-            if os.path.isfile(os.path.join(image_dir, f))
-            and f.lower().endswith((".png", ".jpg", ".jpeg", ".gif", ".bmp"))
-        ]
-        if image_files:
-            selected_imgs = st.multiselect("表示する画像", image_files)
-            selected_paths = [os.path.join(image_dir, img) for img in selected_imgs]
-            st.session_state["selected_image_paths"] = selected_paths
-            for path, img in zip(selected_paths, selected_imgs):
-                st.image(path, caption=img)
+    image_dir_str = str(image_dir)
+    default_images = [
+        os.path.basename(path)
+        for path in selected_paths
+        if os.path.dirname(path) == image_dir_str
+    ]
+
+    selected_imgs = st.multiselect(
+        "表示する画像",
+        image_files,
+        default=default_images,
+    )
+    st.session_state["selected_image_paths"] = [
+        str(image_dir / img) for img in selected_imgs
+    ]
+
+    st.markdown("### 選択中の画像")
+    if st.session_state["selected_image_paths"]:
+        for path in st.session_state["selected_image_paths"]:
+            if os.path.exists(path):
+                st.image(path, caption=os.path.basename(path))
+            else:
+                st.warning(f"画像ファイルが見つかりません: {path}")
+    else:
+        st.info("画像を1枚以上選択してください。")
+
+    # --- 保存処理 ---
+    if st.button("タスクを保存", type="primary"):
+        tasks_text = st.session_state.get("task_description", "")
+        image_paths = st.session_state.get("selected_image_paths", [])
+
+        errors = []
+        if not image_paths:
+            errors.append("画像を1枚以上選択してください。")
+        task_lines = [line.strip() for line in tasks_text.splitlines() if line.strip()]
+        if not task_lines:
+            errors.append("タスクを1行以上入力してください。")
+
+        if errors:
+            for err in errors:
+                st.error(err)
         else:
-            st.session_state["selected_image_paths"] = []
+            name = "\n".join(task_lines)
+            payload = {
+                "house": st.session_state.get("selected_house", ""),
+                "room": st.session_state.get("selected_subfolder", ""),
+                "images": image_paths,
+                "tasks": task_lines,
+                "task_text": "\n".join(task_lines),
+            }
+            upsert_image_task_set(name, payload)
+            st.session_state["current_task_set_choice"] = name
+            st.success("タスクを保存しました。")
+
+    if selected_key != NEW_SET_LABEL and st.button("選択中のタスクを削除", type="secondary"):
+        if selected_key in task_sets:
+            delete_image_task_set(selected_key)
+            st.success("選択中のタスクを削除しました。")
+        else:
+            st.warning("削除対象のタスクが見つかりませんでした。")
+        _reset_form_state()
+        st.rerun()
+
+    st.markdown("### 保存済みタスク一覧")
+    refreshed_sets = load_image_task_sets()
+    if not refreshed_sets:
+        st.info("保存済みのタスクはまだありません。")
+    else:
+        refreshed_choices = build_task_set_choices(refreshed_sets)
+        for label, key in refreshed_choices:
+            data = refreshed_sets.get(key, {})
+            tasks = data.get("tasks", []) if isinstance(data, dict) else []
+            st.markdown(
+                f"- **{label}**: {', '.join(tasks) if tasks else 'タスク未登録'}"
+            )
+
 
 app()


### PR DESCRIPTION
## Summary
- derive task labels from the saved task text and expose helpers for building select-box options
- remove the separate task-set name input, using the task text to identify and manage saved entries in the selection page
- update experiment pages to present the new task labels while keeping image/task metadata in sync

## Testing
- python -m compileall image_task_sets.py pages/images_and_tasks.py pages/experiment_1.py pages/experiment_2.py

------
https://chatgpt.com/codex/tasks/task_e_68d49978e1b48320a3b244a2e7ca91e2