### PR TITLE
Fix experiment image path resolution

### DIFF
--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -23,6 +23,7 @@ from image_task_sets import (
     build_task_set_choices,
     extract_task_lines,
     load_image_task_sets,
+    resolve_image_paths,
 )
 
 load_dotenv()
@@ -146,13 +147,14 @@ def app():
         if isinstance(payload, dict):
             image_candidates = [str(p) for p in payload.get("images", []) if isinstance(p, str)]
 
-        existing_images = [p for p in image_candidates if os.path.exists(p)]
-        missing_images = [p for p in image_candidates if p not in existing_images]
+        existing_images, missing_images = resolve_image_paths(image_candidates)
 
         st.session_state["selected_image_paths"] = existing_images
 
         if missing_images:
-            st.warning("以下の画像ファイルが見つかりません: " + ", ".join(missing_images))
+            st.warning(
+                "以下の画像ファイルが見つかりません: " + ", ".join(missing_images)
+            )
 
         st.markdown("### 選択された画像")
         if existing_images:

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -22,6 +22,7 @@ from image_task_sets import (
     build_task_set_choices,
     extract_task_lines,
     load_image_task_sets,
+    resolve_image_paths,
 )
 
 from two_classify import prepare_data  # 既存関数を利用
@@ -224,13 +225,14 @@ def app():
         if isinstance(payload, dict):
             image_candidates = [str(p) for p in payload.get("images", []) if isinstance(p, str)]
 
-        existing_images = [p for p in image_candidates if os.path.exists(p)]
-        missing_images = [p for p in image_candidates if p not in existing_images]
+        existing_images, missing_images = resolve_image_paths(image_candidates)
 
         st.session_state["selected_image_paths"] = existing_images
 
         if missing_images:
-            st.warning("以下の画像ファイルが見つかりません: " + ", ".join(missing_images))
+            st.warning(
+                "以下の画像ファイルが見つかりません: " + ", ".join(missing_images)
+            )
 
         st.markdown("### 選択された画像")
         if existing_images:


### PR DESCRIPTION
## Summary
- add utilities to resolve stored image paths relative to the project root
- update experiment pages to use the shared resolver when loading saved image/task sets

## Testing
- python -m compileall image_task_sets.py pages

------
https://chatgpt.com/codex/tasks/task_e_68d4d7e42c108320b469962c85452419