### PR TITLE
Fix image path resolution on Linux

### DIFF
--- a/image_task_sets.py
+++ b/image_task_sets.py
@@ -127,7 +127,14 @@ def resolve_image_path(path_str: str) -> Path:
     directory.
     """
 
-    original = Path(str(path_str))
+    # ``path_str`` may come from Windows environments where the path was saved
+    # with backslashes (e.g. ``images\house2\LIVING\00051-rgb.png``).  On
+    # Linux these backslashes are treated as literal characters which prevents
+    # ``Path`` from resolving the file correctly.  Normalise the separators
+    # before constructing the ``Path`` object so the resolution logic works
+    # irrespective of the originating platform.
+    normalised = str(path_str).replace("\\", "/")
+    original = Path(normalised)
     candidates = [original]
 
     if not original.is_absolute():


### PR DESCRIPTION
## Summary
- normalise stored image paths by replacing Windows backslashes with POSIX separators before resolving

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4e6d91d7883209d7b2679efac0cd2