### PR TITLE
Handle dict-wrapped joblib models in predict_with_model

### DIFF
--- a/jsonl.py
+++ b/jsonl.py
@@ -333,7 +333,14 @@ def predict_with_model():
         information,
     )
     model_path = Path(st.session_state.get("model_path", MODEL_PATH))
-    model = joblib.load(model_path)
+    obj = joblib.load(model_path)
+    if isinstance(obj, dict):
+        model = obj["model"]
+        th = float(obj.get("threshold", 0.5))
+    else:
+        model = obj
+        th = 0.5  # 後方互換
+
     pred = model.predict([text])[0]
     label = "sufficient" if pred == 1 else "insufficient"
 
@@ -350,14 +357,6 @@ def predict_with_model():
     st.session_state.saved_jsonl.append(entry)
 
     _save_to_firestore(entry, collection_override="predict_with_model")
-    
-    obj = joblib.load(model_path)
-    if isinstance(obj, dict):
-        model = obj["model"]
-        th = float(obj.get("threshold", 0.5))
-    else:
-        model = obj
-        th = 0.5  # 後方互換
 
     p = float(model.predict_proba([text])[0, 1])
     label = "sufficient" if p >= th else "insufficient"


### PR DESCRIPTION
## Summary
- handle joblib artifacts that wrap the model and threshold in a dictionary before calling prediction APIs in `predict_with_model`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d504cafaac832098d695d7c4197725