### PR TITLE
Persist randomly assigned tasks per session

### DIFF
--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -109,9 +109,15 @@ def app():
                 st.session_state["experiment1_selected_task_set"] = None
                 payload = {}
             else:
-                # ランダム選択
-                selected_label = random.choice(labels)
-                st.selectbox("タスク", labels, index=labels.index(selected_label))
+                stored_label = st.session_state.get("experiment1_selected_task_label")
+                if stored_label not in labels:
+                    stored_label = random.choice(labels)
+                selected_label = st.selectbox(
+                    "タスク",
+                    labels,
+                    index=labels.index(stored_label),
+                )
+                st.session_state["experiment1_selected_task_label"] = selected_label
                 selected_task_name = label_to_key.get(selected_label)
                 st.session_state["experiment1_selected_task_set"] = selected_task_name
                 payload = task_sets.get(selected_task_name, {}) if selected_task_name else {}

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -187,9 +187,15 @@ def app():
                 st.session_state["experiment2_selected_task_set"] = None
                 payload = {}
             else:
-                # ランダム選択
-                selected_label = random.choice(labels)
-                st.selectbox("タスク", labels, index=labels.index(selected_label))
+                stored_label = st.session_state.get("experiment2_selected_task_label")
+                if stored_label not in labels:
+                    stored_label = random.choice(labels)
+                selected_label = st.selectbox(
+                    "タスク",
+                    labels,
+                    index=labels.index(stored_label),
+                )
+                st.session_state["experiment2_selected_task_label"] = selected_label
                 selected_task_name = label_to_key.get(selected_label)
                 st.session_state["experiment2_selected_task_set"] = selected_task_name
                 payload = task_sets.get(selected_task_name, {}) if selected_task_name else {}


### PR DESCRIPTION
## Summary
- cache the randomly assigned task label for Experiment 1 in Streamlit session state so it survives reruns
- do the same for Experiment 2 so the task only changes when the session state is cleared

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d504c927b083209084938113d24bcf