### PR TITLE
Reset random tasks when conversations restart

### DIFF
--- a/pages/pre-experiment.py
+++ b/pages/pre-experiment.py
@@ -19,7 +19,7 @@ from run_and_show import (
 )
 from run_and_show import show_provisional_output
 from strips import extract_between, strip_tags
-from tasks.ui import render_random_room_task
+from tasks.ui import render_random_room_task, reset_random_room_task
 
 load_dotenv()
 
@@ -271,6 +271,7 @@ def app():
                         "clarifying_steps": []
                     }
                     st.session_state.saved_jsonl = []
+                    reset_random_room_task("pre_experiment")
                     st.rerun()
                 st.stop()
 
@@ -299,6 +300,7 @@ def app():
         }
         st.session_state.saved_jsonl = []
         st.session_state["chat_input_history"] = []
+        reset_random_room_task("pre_experiment")
         st.rerun()
 
 app()

--- a/pages/save_data.py
+++ b/pages/save_data.py
@@ -13,7 +13,7 @@ from jsonl import (
 )
 from move_functions import move_to, pick_object, place_object_next_to, place_object_on
 from run_and_show import run_plan_and_show, show_clarifying_question, show_function_sequence, show_information
-from tasks.ui import render_random_room_task
+from tasks.ui import render_random_room_task, reset_random_room_task
 
 load_dotenv()
 
@@ -252,6 +252,7 @@ def app():
                     st.session_state.saved_jsonl = []
                     st.session_state.information_items = []
                     st.session_state["chat_input_history"] = []
+                    reset_random_room_task("save_data")
                     st.rerun()
                 st.stop()
 

--- a/tasks/ui.py
+++ b/tasks/ui.py
@@ -51,3 +51,16 @@ def render_random_room_task(
     if task:
         st.success(f"部屋「{room_name}」のタスク例：{task}")
     return task
+
+
+def reset_random_room_task(state_prefix: str) -> None:
+    """Re-roll the random task associated with ``state_prefix`` if possible."""
+
+    task_state_key = f"{state_prefix}_random_task"
+    room_state_key = f"{state_prefix}_task_room"
+    room_name = st.session_state.get(room_state_key, "")
+
+    if room_name:
+        st.session_state[task_state_key] = choose_random_task(room_name)
+    else:
+        st.session_state[task_state_key] = None


### PR DESCRIPTION
## Summary
- add a helper to reroll the random task associated with a page
- reroll the random task whenever the conversation reset button is pressed on the pre-experiment and data collection pages

## Testing
- python -m compileall tasks/ui.py pages/pre-experiment.py pages/save_data.py

------
https://chatgpt.com/codex/tasks/task_e_68d51857d8788320b8a78cd9a1b1274c