### PR TITLE
Handle Firestore credentials from JSON env vars

### DIFF
--- a/jsonl.py
+++ b/jsonl.py
@@ -138,12 +138,13 @@ def _save_to_firestore(entry, collection_override=None):
     if not credentials:
         print("[Firestore] skipped: no FIREBASE_CREDENTIALS")
         return
-    if not Path(credentials).exists():
-        print(f"[Firestore] skipped: credentials file not found at {credentials}")
-        return
     try:
         save_document(collection, entry, credentials)
         print(f"[Firestore] saved to {collection}")
+    except FileNotFoundError:
+        print(f"[Firestore] skipped: credentials file not found or inaccessible: {credentials}")
+    except ValueError as e:
+        print(f"[Firestore] skipped: invalid credential JSON provided: {e}")
     except Exception as e:
         # Streamlit なら st.error でも良い
         print(f"[Firestore] ERROR saving to {collection}: {e}")


### PR DESCRIPTION
## Summary
- allow Firestore helper to load credentials from either file paths or JSON strings so Cloud Run secrets work
- improve Firestore save logging to handle invalid or missing credential sources gracefully

## Testing
- python -m compileall firebase_utils.py jsonl.py

------
https://chatgpt.com/codex/tasks/task_e_68d7446a3bd88320a4ba6df844f811ea