### PR TITLE
Add consent gate before accessing experiment pages

### DIFF
--- a/consent.py
+++ b/consent.py
@@ -1,0 +1,76 @@
+"""Streamlit helpers for obtaining participant consent before running the app."""
+
+from __future__ import annotations
+
+import streamlit as st
+
+
+CONSENT_TEXT = """
+### 研究への参加と個人情報の取り扱いについて
+
+本研究は、人間とAIとの対話が家庭用ロボットの行動計画に与える影響を明らかにすることを目的としています。本アプリでは、指示文とロボットの行動計画、ユーザーとの対話内容に関する記録を取得します。
+
+#### 1. 参加の任意性と撤回の自由
+- 参加は完全に任意であり、同意後であっても不利益なく撤回できます。
+- 撤回したい場合は、画面上の案内に従っていつでも同意を取り消してください。
+
+#### 2. 研究の実施内容
+- 画面に表示されるタスクに関して、家庭用ロボットに与える指示を入力し、AIとの対話を通じて行動計画を作成します。
+- 所要時間は1セッションあたり約15〜20分を想定していますが、途中で中止しても問題ありません。
+
+#### 3. 取得するデータ
+- 入力されたテキスト、会話ログ、アプリ操作に関する記録を保存します。
+- 取得データから個人を特定できる情報は収集しません。個人が特定される恐れがある情報を入力しないようご留意ください。
+
+#### 4. 個人情報とプライバシーの保護
+- 収集データは匿名化した上で安全に保管し、研究目的以外には利用しません。
+- 研究成果を学会等で発表する際も、個人が特定される形で情報を公開することはありません。
+
+#### 5. 期待される利益と潜在的な不利益
+- 参加者個人に直接的な金銭的報酬や利益はありませんが、家庭用ロボットのユーザー体験向上に資する研究に貢献できます。
+- 実験中、AIとの対話内容によってストレスや不快感を覚える可能性があります。不快に感じた場合は速やかに参加を中止してください。
+
+#### 6. 利益相反に関する情報
+- 本研究は LLMATCH 内で実施され、研究員は関連企業からの資金提供や利害関係を有していません。
+- 研究成果は学術的知見として公開されますが、特定企業の宣伝を目的としていません。
+
+#### 7. お問い合わせ
+- 研究内容やデータの取り扱いに関するご質問は、Slack の [@Kaoru Yoshida](https://matsuokenllmcommunity.slack.com/team/U071ML4LY5C) までお問い合わせください。
+
+上記の説明を読み、内容を理解した上で参加に同意する場合は、以下のチェックボックスをオンにしてボタンを押してください。
+"""
+
+
+def _render_consent_form() -> None:
+    """Render the consent form and stop execution until the user agrees."""
+
+    st.set_page_config(page_title="研究参加に関する同意", layout="wide")
+    st.title("研究参加の同意について")
+    st.markdown(CONSENT_TEXT)
+
+    with st.form("consent_form", clear_on_submit=False):
+        agree = st.checkbox("上記の説明を読み、研究に参加することに同意します。", value=False)
+        submit = st.form_submit_button("同意して実験に進む", use_container_width=True)
+
+    if submit:
+        if agree:
+            st.session_state["consent_given"] = True
+            st.success("ご同意ありがとうございます。実験画面に進みます。")
+            st.experimental_rerun()
+        else:
+            st.error("参加には同意が必要です。チェックボックスにチェックを入れてください。")
+
+    st.stop()
+
+
+def require_consent(*, allow_withdrawal: bool = False) -> None:
+    """Ensure that the participant has given consent before proceeding."""
+
+    if not st.session_state.get("consent_given"):
+        _render_consent_form()
+
+    if allow_withdrawal:
+        with st.sidebar:
+            if st.button("同意を撤回してトップに戻る", type="secondary"):
+                st.session_state["consent_given"] = False
+                st.experimental_rerun()

--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -1,4 +1,5 @@
 import streamlit as st
+from consent import require_consent
 import json
 import os
 import random
@@ -48,6 +49,7 @@ def _update_random_task_selection(label_key: str, labels_key: str, mapping_key: 
 
 
 def app():
+    require_consent()
     st.title("LLMATCH Criticデモアプリ")
     st.subheader("実験1 GPTとGPT with Criticの比較")
     

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -5,6 +5,7 @@ import re
 
 import joblib
 import streamlit as st
+from consent import require_consent
 from dotenv import load_dotenv
 
 from api import (
@@ -109,6 +110,7 @@ def get_critic_label(context):
     return "sufficient" if pred[0] == 1 else "insufficient"
 
 def app():
+    require_consent()
     st.title("LLMATCH Criticデモアプリ")
     st.subheader("実験2 異なるコミュニケーションタイプの比較")
     

--- a/pages/images_and_tasks.py
+++ b/pages/images_and_tasks.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Dict, List
 
 import streamlit as st
+from consent import require_consent
 from dotenv import load_dotenv
 
 from image_task_sets import (
@@ -77,6 +78,7 @@ def _populate_form_from_set(name: str, payload: Dict[str, object]) -> None:
 
 
 def app():
+    require_consent()
     st.title("LLMATCH Criticデモアプリ")
     st.subheader("写真とタスクの選定・保存")
 

--- a/pages/pre-experiment.py
+++ b/pages/pre-experiment.py
@@ -1,7 +1,9 @@
 import streamlit as st
+from consent import require_consent
 import json
 import os
 from difflib import SequenceMatcher
+from pathlib import Path
 from dotenv import load_dotenv
 
 from api import client, SYSTEM_PROMPT, build_bootstrap_user_message
@@ -85,6 +87,7 @@ def finalize_and_render_plan(label: str):
         st.write(f"{sim:.2f}")
 
 def app():
+    require_consent()
     st.title("LLMATCH Criticデモアプリ")
     st.subheader("プレ実験")
     st.write("目的：GPT with Criticの学習の効果を図る。")

--- a/pages/save_data.py
+++ b/pages/save_data.py
@@ -3,6 +3,7 @@ import os
 import re
 
 import streamlit as st
+from consent import require_consent
 from dotenv import load_dotenv
 
 from api import client, build_bootstrap_user_message, CREATING_DATA_SYSTEM_PROMPT
@@ -31,6 +32,7 @@ def accumulate_information(reply: str) -> str:
 
 
 def app():
+    require_consent()
     st.title("LLMATCH Criticデモアプリ")
     
     st.sidebar.subheader("行動計画で使用される関数")

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,6 +1,9 @@
 import streamlit as st
 
+from consent import require_consent
+
 def app():
+    require_consent(allow_withdrawal=True)
     st.title("LLMATCH Criticデモアプリ")
     st.subheader("実験方法と利用案内")
     st.warning("このページの内容は、以下のGoogleドキュメントと同じ内容です。")


### PR DESCRIPTION
## Summary
- add a reusable consent helper that renders the participation agreement before continuing into the app
- require consent on the landing page and every experiment-related page, including an option to withdraw on the home screen

## Testing
- python -m compileall streamlit_app.py consent.py pages

------
https://chatgpt.com/codex/tasks/task_e_68d7365b9b708320bf5a7eeaca4408bc