### PR TITLE
Hide sidebar navigation on experiment pages

### DIFF
--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -31,6 +31,46 @@ from image_task_sets import (
 load_dotenv()
 
 
+st.set_page_config(initial_sidebar_state="collapsed")
+
+SIDEBAR_HIDE_STYLE = """
+    <style>
+        [data-testid="stSidebar"] {display: none !important;}
+        [data-testid="stSidebarNav"] {display: none !important;}
+        [data-testid="collapsedControl"] {display: none !important;}
+    </style>
+"""
+
+FUNCTION_DOCS = """
+- **move_to(room_name:str)**
+  指定した部屋へロボットを移動します。
+
+- **pick_object(object:str)**
+  指定した物体をつかみます。
+
+- **place_object_next_to(object:str, target:str)**
+  指定した物体をターゲットの横に置きます。
+
+- **place_object_on(object:str, target:str)**
+  指定した物体をターゲットの上に置きます。
+
+- **place_object_in(object:str, target:str)**
+  指定した物体をターゲットの中に入れます。
+
+- **detect_object(object:str)**
+  指定した物体を検出します。
+
+- **search_about(object:str)**
+  指定した物体に関する情報を検索します。
+
+- **push(object:str)**
+  指定した物体を押します。
+
+- **say(text:str)**
+  指定したテキストを発話します。
+"""
+
+
 def _update_random_task_selection(label_key: str, labels_key: str, mapping_key: str, set_key: str) -> None:
     """Select a new task label at random and update related session state."""
 
@@ -50,38 +90,11 @@ def _update_random_task_selection(label_key: str, labels_key: str, mapping_key: 
 def app():
     st.title("LLMATCH Criticデモアプリ")
     st.subheader("実験1 GPTとGPT with Criticの比較")
-    
-    st.sidebar.subheader("行動計画で使用される関数")
-    st.sidebar.markdown(
-    """
-    - **move_to(room_name:str)**  
-    指定した部屋へロボットを移動します。
 
-    - **pick_object(object:str)**  
-    指定した物体をつかみます。
+    st.markdown(SIDEBAR_HIDE_STYLE, unsafe_allow_html=True)
 
-    - **place_object_next_to(object:str, target:str)**  
-    指定した物体をターゲットの横に置きます。
-
-    - **place_object_on(object:str, target:str)**  
-    指定した物体をターゲットの上に置きます。
-
-    - **place_object_in(object:str, target:str)**  
-    指定した物体をターゲットの中に入れます。
-
-    - **detect_object(object:str)**  
-    指定した物体を検出します。
-
-    - **search_about(object:str)**  
-    指定した物体に関する情報を検索します。
-
-    - **push(object:str)**  
-    指定した物体を押します。
-
-    - **say(text:str)**  
-    指定したテキストを発話します。
-    """
-    )
+    st.markdown("### 行動計画で使用される関数")
+    st.markdown(FUNCTION_DOCS)
 
     mode_options = ["GPT", "GPT with critic"]
     default_mode = st.session_state.get("mode", "GPT with critic")

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -28,6 +28,46 @@ from two_classify import prepare_data  # 既存関数を利用
 
 load_dotenv()
 
+
+st.set_page_config(initial_sidebar_state="collapsed")
+
+SIDEBAR_HIDE_STYLE = """
+    <style>
+        [data-testid="stSidebar"] {display: none !important;}
+        [data-testid="stSidebarNav"] {display: none !important;}
+        [data-testid="collapsedControl"] {display: none !important;}
+    </style>
+"""
+
+FUNCTION_DOCS = """
+- **move_to(room_name:str)**
+  指定した部屋へロボットを移動します。
+
+- **pick_object(object:str)**
+  指定した物体をつかみます。
+
+- **place_object_next_to(object:str, target:str)**
+  指定した物体をターゲットの横に置きます。
+
+- **place_object_on(object:str, target:str)**
+  指定した物体をターゲットの上に置きます。
+
+- **place_object_in(object:str, target:str)**
+  指定した物体をターゲットの中に入れます。
+
+- **detect_object(object:str)**
+  指定した物体を検出します。
+
+- **search_about(object:str)**
+  指定した物体に関する情報を検索します。
+
+- **push(object:str)**
+  指定した物体を押します。
+
+- **say(text:str)**
+  指定したテキストを発話します。
+"""
+
 def _update_random_task_selection(label_key: str, labels_key: str, mapping_key: str, set_key: str) -> None:
     """Select a new task label at random and update related session state."""
 
@@ -111,38 +151,11 @@ def get_critic_label(context):
 def app():
     st.title("LLMATCH Criticデモアプリ")
     st.subheader("実験2 異なるコミュニケーションタイプの比較")
-    
-    st.sidebar.subheader("行動計画で使用される関数")
-    st.sidebar.markdown(
-    """
-    - **move_to(room_name:str)**  
-    指定した部屋へロボットを移動します。
 
-    - **pick_object(object:str)**  
-    指定した物体をつかみます。
+    st.markdown(SIDEBAR_HIDE_STYLE, unsafe_allow_html=True)
 
-    - **place_object_next_to(object:str, target:str)**  
-    指定した物体をターゲットの横に置きます。
-
-    - **place_object_on(object:str, target:str)**  
-    指定した物体をターゲットの上に置きます。
-
-    - **place_object_in(object:str, target:str)**  
-    指定した物体をターゲットの中に入れます。
-
-    - **detect_object(object:str)**  
-    指定した物体を検出します。
-
-    - **search_about(object:str)**  
-    指定した物体に関する情報を検索します。
-
-    - **push(object:str)**  
-    指定した物体を押します。
-
-    - **say(text:str)**  
-    指定したテキストを発話します。
-    """
-    )
+    st.markdown("### 行動計画で使用される関数")
+    st.markdown(FUNCTION_DOCS)
 
     prompt_options = {
         "1": SYSTEM_PROMPT_STANDARD,


### PR DESCRIPTION
## Summary
- hide the Streamlit sidebar on the experiment pages to prevent accidental navigation
- surface the list of available robot action functions within the main experiment content area

## Testing
- streamlit run streamlit_app.py --server.port=8501 --server.address=0.0.0.0


------
https://chatgpt.com/codex/tasks/task_e_68d7366c92f483208278acdad9a2900a