### PR TITLE
Ensure consent redirects to instructions

### DIFF
--- a/consent.py
+++ b/consent.py
@@ -55,6 +55,7 @@ def _render_consent_form() -> None:
     if submit:
         if agree:
             st.session_state["consent_given"] = True
+            st.session_state["redirect_to_instruction_page"] = True
             st.success("ご同意ありがとうございます。実験画面に進みます。")
             st.rerun()
         else:
@@ -63,11 +64,17 @@ def _render_consent_form() -> None:
     st.stop()
 
 
-def require_consent(*, allow_withdrawal: bool = False) -> None:
+def require_consent(
+    *, allow_withdrawal: bool = False, redirect_to_instructions: bool = True
+) -> None:
     """Ensure that the participant has given consent before proceeding."""
 
     if not st.session_state.get("consent_given"):
         _render_consent_form()
+
+    if redirect_to_instructions and st.session_state.get("redirect_to_instruction_page"):
+        st.session_state["redirect_to_instruction_page"] = False
+        st.switch_page("streamlit_app.py")
 
     if allow_withdrawal:
         with st.sidebar:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -3,7 +3,9 @@ import streamlit as st
 from consent import require_consent
 
 def app():
-    require_consent(allow_withdrawal=True)
+    require_consent(allow_withdrawal=True, redirect_to_instructions=False)
+    if st.session_state.get("redirect_to_instruction_page"):
+        st.session_state["redirect_to_instruction_page"] = False
     st.title("LLMATCH Criticデモアプリ")
     st.subheader("実験方法と利用案内")
     st.warning("このページの内容は、以下のGoogleドキュメントと同じ内容です。")


### PR DESCRIPTION
## Summary
- add a redirect flag so that consenting participants are sent to the experiment overview page before other pages
- prevent the overview page from re-triggering the redirect once instructions have been shown

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d87b11bbe48320a073037c6a607016