### PR TITLE
Reset Experiment 2 state when switching prompts

### DIFF
--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -333,6 +333,10 @@ def app():
             "clarifying_steps": []
         }
         st.session_state["chat_input_history"] = []
+        st.session_state.turn_count = 0
+        st.session_state.force_end = False
+        st.session_state.end_reason = []
+        st.session_state.active = True
     if "active" not in st.session_state:
         st.session_state.active = True
     if "turn_count" not in st.session_state:


### PR DESCRIPTION
## Summary
- reset experiment 2 conversation state when a new system prompt is loaded
- ensure force_end, turn_count, and end_reason reset so the chat input is shown

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9bcde8a5083208552624c0827b8a3