### PR TITLE
Prevent auto scroll to bottom after page navigation

### DIFF
--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -1,4 +1,5 @@
 import streamlit as st
+import streamlit.components.v1 as components
 from consent import (
     apply_sidebar_hiding,
     configure_page,
@@ -38,6 +39,29 @@ load_dotenv()
 
 
 configure_page(hide_sidebar_for_participant=True)
+
+
+SCROLL_RESET_FLAG_KEY = "experiment1_scroll_reset_done"
+
+
+def _scroll_to_top_on_first_load() -> None:
+    if st.session_state.get(SCROLL_RESET_FLAG_KEY):
+        return
+    components.html(
+        """
+        <script>
+        const doc = window.parent ? window.parent.document : document;
+        const main = doc ? doc.querySelector('section.main') : null;
+        if (main) {
+            main.scrollTo(0, 0);
+        } else {
+            window.scrollTo(0, 0);
+        }
+        </script>
+        """,
+        height=0,
+    )
+    st.session_state[SCROLL_RESET_FLAG_KEY] = True
 
 def _reset_conversation_state(system_prompt: str) -> None:
     """Reset conversation-related session state for experiment 1."""
@@ -81,6 +105,7 @@ def _update_random_task_selection(label_key: str, labels_key: str, mapping_key: 
 
 def app():
     require_consent()
+    _scroll_to_top_on_first_load()
     st.title("LLMATCH Criticデモアプリ")
     st.subheader("実験1 GPTとGPT with Criticの比較")
 
@@ -425,6 +450,8 @@ def app():
         if st.button("🙆‍♂️はい → 実験2", key="followup_yes", type="primary"):
             st.session_state["experiment1_followup_prompt"] = False
             st.session_state.pop("experiment1_followup_choice", None)
+            st.session_state.pop(SCROLL_RESET_FLAG_KEY, None)
+            st.session_state.pop("experiment2_scroll_reset_done", None)
             st.switch_page("pages/experiment_2.py")
 
 app()

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -5,6 +5,7 @@ import re
 
 import joblib
 import streamlit as st
+import streamlit.components.v1 as components
 from consent import (
     apply_sidebar_hiding,
     configure_page,
@@ -35,6 +36,29 @@ load_dotenv()
 
 
 configure_page(hide_sidebar_for_participant=True)
+
+
+SCROLL_RESET_FLAG_KEY = "experiment2_scroll_reset_done"
+
+
+def _scroll_to_top_on_first_load() -> None:
+    if st.session_state.get(SCROLL_RESET_FLAG_KEY):
+        return
+    components.html(
+        """
+        <script>
+        const doc = window.parent ? window.parent.document : document;
+        const main = doc ? doc.querySelector('section.main') : null;
+        if (main) {
+            main.scrollTo(0, 0);
+        } else {
+            window.scrollTo(0, 0);
+        }
+        </script>
+        """,
+        height=0,
+    )
+    st.session_state[SCROLL_RESET_FLAG_KEY] = True
 
 def _reset_conversation_state(system_prompt: str) -> None:
     """Reset conversation-related session state for experiment 1."""
@@ -186,6 +210,7 @@ def get_critic_label(context):
 
 def app():
     require_consent()
+    _scroll_to_top_on_first_load()
     st.title("LLMATCH Criticデモアプリ")
     st.subheader("実験2 異なるコミュニケーションタイプの比較")
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -70,6 +70,8 @@ def app():
     
     if st.button("実験を始める", use_container_width=True, type="primary"):
         st.session_state["redirect_to_instruction_page"] = False
+        st.session_state.pop("experiment1_scroll_reset_done", None)
+        st.session_state.pop("experiment2_scroll_reset_done", None)
         st.switch_page("pages/experiment_1.py")
 
 app()


### PR DESCRIPTION
## Summary
- add a helper on the experiment pages that scrolls the main content back to the top on the first load of the page
- reset the per-page scroll flags before navigating so newly opened pages no longer jump to the bottom automatically

## Testing
- python -m compileall streamlit_app.py pages/experiment_1.py pages/experiment_2.py

------
https://chatgpt.com/codex/tasks/task_e_68dbc6161288832086f34e77797d65ff