### PR TITLE
Render chat history in scrollable containers

### DIFF
--- a/chat_display.py
+++ b/chat_display.py
@@ -1,0 +1,143 @@
+import html
+from typing import Iterable, Mapping, Any, Optional
+
+import streamlit as st
+
+_ROLE_LABELS = {
+    "assistant": "ロボット",
+    "user": "ユーザー",
+    "tool": "ツール",
+}
+
+
+def _normalize_content(content: Any) -> str:
+    if isinstance(content, str):
+        return html.escape(content).replace("\n", "<br>")
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, dict):
+                item_type = item.get("type")
+                if item_type == "text":
+                    parts.append(html.escape(item.get("text", "")))
+                elif item_type == "image_url":
+                    url = ""
+                    image_payload = item.get("image_url")
+                    if isinstance(image_payload, dict):
+                        url = image_payload.get("url", "")
+                    if isinstance(url, str) and url.startswith("data:"):
+                        parts.append("📷 ローカル画像が添付されています。")
+                    elif url:
+                        safe_url = html.escape(url)
+                        parts.append(
+                            f"📷 画像: <a href=\"{safe_url}\" target=\"_blank\">リンクを開く</a>"
+                        )
+                    else:
+                        parts.append("📷 画像が添付されています。")
+                else:
+                    parts.append(html.escape(str(item)))
+            else:
+                parts.append(html.escape(str(item)))
+        return "<br>".join(parts)
+    if content is None:
+        return ""
+    return html.escape(str(content)).replace("\n", "<br>")
+
+
+def _format_message(role: Optional[str], content: Any) -> str:
+    normalized = _normalize_content(content)
+    role_key = role or "unknown"
+    label = _ROLE_LABELS.get(role_key, role_key)
+    classes = ["custom-chat-message"]
+    if role_key in ("assistant", "user", "tool"):
+        classes.append(f"custom-chat-{role_key}")
+    else:
+        classes.append("custom-chat-other")
+    return (
+        f"<div class='{' '.join(classes)}'>"
+        f"<div class='custom-chat-role'>{html.escape(str(label))}</div>"
+        f"<div class='custom-chat-content'>{normalized}</div>"
+        "</div>"
+    )
+
+
+def render_chat_history(
+    messages: Iterable[Mapping[str, Any]],
+    *,
+    greeting: Optional[str] = None,
+    height: int = 400,
+) -> None:
+    """Render chat messages inside a scrollable container."""
+
+    if "__chat_history_style_injected" not in st.session_state:
+        st.session_state["__chat_history_style_injected"] = True
+        st.markdown(
+            """
+            <style>
+            .custom-chat-history {
+                border: 1px solid #dcdcdc;
+                border-radius: 0.75rem;
+                background: #f9f9f9;
+                padding: 1rem;
+            }
+            .custom-chat-message {
+                margin-bottom: 0.75rem;
+                padding: 0.5rem 0.75rem;
+                border-radius: 0.5rem;
+                background: white;
+                box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+            }
+            .custom-chat-message:last-child {
+                margin-bottom: 0;
+            }
+            .custom-chat-role {
+                font-weight: 600;
+                margin-bottom: 0.25rem;
+                color: #444;
+            }
+            .custom-chat-assistant {
+                border-left: 4px solid #4c8bf5;
+            }
+            .custom-chat-user {
+                border-left: 4px solid #34a853;
+            }
+            .custom-chat-tool {
+                border-left: 4px solid #fbbc05;
+            }
+            .custom-chat-other {
+                border-left: 4px solid #999;
+            }
+            .custom-chat-content {
+                color: #1f1f1f;
+                line-height: 1.5;
+                word-break: break-word;
+            }
+            .custom-chat-empty {
+                color: #777;
+            }
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
+
+    items = []
+    if greeting:
+        items.append(_format_message("assistant", greeting))
+
+    for msg in messages:
+        role = msg.get("role") if isinstance(msg, Mapping) else None
+        if role == "system":
+            continue
+        content = msg.get("content") if isinstance(msg, Mapping) else None
+        items.append(_format_message(role, content))
+
+    if not items:
+        items.append("<div class='custom-chat-empty'>まだメッセージはありません。</div>")
+
+    safe_height = max(200, height)
+    history_html = (
+        f"<div class='custom-chat-history' style='height: {safe_height}px; overflow: auto;'>"
+        + "".join(items)
+        + "</div>"
+    )
+    st.markdown(history_html, unsafe_allow_html=True)

--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -14,6 +14,7 @@ import joblib
 from dotenv import load_dotenv
 
 from api import client, SYSTEM_PROMPT, build_bootstrap_user_message
+from chat_display import render_chat_history
 from jsonl import predict_with_model, save_experiment_1_result
 from move_functions import (
     move_to,
@@ -259,8 +260,7 @@ def app():
              "自動で評価フォームが表示されるまで会話を続けてください。")
     context = st.session_state["context"]
 
-    message = st.chat_message("assistant")
-    message.write("こんにちは、私は家庭用ロボットです！あなたの指示に従って行動します。")
+    greeting_text = "こんにちは、私は家庭用ロボットです！あなたの指示に従って行動します。"
 
     max_turns = 5
     should_stop = False
@@ -302,17 +302,16 @@ def app():
         
     # 画面下部に履歴を全表示（systemは省く）
     last_assistant_idx = max((i for i, m in enumerate(context) if m["role"] == "assistant"), default=None)
-    
+
+    render_chat_history(context, greeting=greeting_text, height=420)
+
     for i, msg in enumerate(context):
-        if msg["role"] == "system":
+        if msg["role"] != "assistant":
             continue
-        with st.chat_message(msg["role"]):
-            st.write(msg["content"])
-            if msg["role"] == "assistant":
-                if i == last_assistant_idx and "<FunctionSequence>" in msg["content"]:
-                    run_plan_and_show(msg["content"])
-                show_function_sequence(msg["content"])
-                show_clarifying_question(msg["content"])
+        if i == last_assistant_idx and isinstance(msg.get("content"), str) and "<FunctionSequence>" in msg["content"]:
+            run_plan_and_show(msg["content"])
+        show_function_sequence(msg["content"])
+        show_clarifying_question(msg["content"])
     assistant_messages = [m for m in context if m["role"] == "assistant"]
     if assistant_messages:
         label, p, th = predict_with_model()

--- a/pages/pre-experiment.py
+++ b/pages/pre-experiment.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from dotenv import load_dotenv
 
 from api import client, SYSTEM_PROMPT, build_bootstrap_user_message
+from chat_display import render_chat_history
 from jsonl import predict_with_model, save_pre_experiment_result
 from move_functions import (
     move_to,
@@ -234,9 +235,7 @@ def app():
         st.session_state["pending_user_input"] = selected_inst
 
     context = st.session_state["context"]
-
-    message = st.chat_message("assistant")
-    message.write("こんにちは、私は家庭用ロボットです！あなたの指示に従って行動します。")
+    greeting_text = "こんにちは、私は家庭用ロボットです！あなたの指示に従って行動します。"
     input_box = st.chat_input("ロボットへの回答を入力してください", key="pre-experiment_chat_input")
     if input_box:
         st.session_state["chat_input_history"].append(input_box)
@@ -278,20 +277,7 @@ def app():
                     st.rerun()
                 st.stop()
 
-    last_assistant_idx = max((i for i, m in enumerate(context) if m["role"] == "assistant"), default=None)
-        
-    # 画面下部に履歴を全表示（systemは省く）
-
-    for i, msg in enumerate(context):
-        if msg["role"] == "system":
-            continue
-        with st.chat_message(msg["role"]):
-            st.write(msg["content"])
-        
-        # if i == last_assistant_idx:
-        #     show_provisional_output(msg["content"])
-
-        # if i == last_assistant_idx: #and "<FinalOutput>" in msg["content"]:
+    render_chat_history(context, greeting=greeting_text, height=420)
             
     if st.button("⚠️会話をリセット", key="reset_conv"):
         # セッション情報を初期化

--- a/pages/save_data.py
+++ b/pages/save_data.py
@@ -7,6 +7,7 @@ from consent import require_consent
 from dotenv import load_dotenv
 
 from api import client, build_bootstrap_user_message, CREATING_DATA_SYSTEM_PROMPT
+from chat_display import render_chat_history
 from jsonl import (
     remove_last_jsonl_entry,
     save_jsonl_entry,
@@ -205,19 +206,19 @@ def app():
     # 4) 画面下部に履歴を全表示（systemは省く）
     last_assistant_idx = max((i for i, m in enumerate(context) if m["role"] == "assistant"), default=None)
 
+    render_chat_history(context, height=420)
+
     for i, msg in enumerate(context):
-        if msg["role"] == "system":
+        if msg["role"] != "assistant":
             continue
-        with st.chat_message(msg["role"]):
-            st.write(msg["content"])
-            if msg["role"] == "assistant":
-                if i == last_assistant_idx and "<FunctionSequence>" in msg["content"]:
-                    run_plan_and_show(msg["content"])
-                show_function_sequence(msg["content"])
-                show_clarifying_question(msg["content"])
-                show_information(msg["content"])
+        content = msg.get("content")
+        if i == last_assistant_idx and isinstance(content, str) and "<FunctionSequence>" in content:
+            run_plan_and_show(content)
+        show_function_sequence(content)
+        show_clarifying_question(content)
+        show_information(content)
         # 最後のアシスタント直後にボタンを出す（計画があるときのみ）
-        if i == last_assistant_idx and "<FunctionSequence>" in msg["content"]:
+        if i == last_assistant_idx and isinstance(content, str) and "<FunctionSequence>" in content:
             st.write("この計画はロボットが実行するのに十分ですか？")
             col1, col2 = st.columns(2)
 


### PR DESCRIPTION
## Summary
- add a reusable `render_chat_history` helper that renders conversations inside a fixed-height, scrollable div and formats text, images, and default labels
- update the experiment and data collection pages to use the new scrollable chat history while preserving existing evaluation logic

## Testing
- python -m compileall chat_display.py pages

------
https://chatgpt.com/codex/tasks/task_e_68dbd897766883209d604cabfde204aa