### PR TITLE
Ensure experiment pages scroll to top after navigation

### DIFF
--- a/pages/experiment_1.py
+++ b/pages/experiment_1.py
@@ -42,26 +42,32 @@ configure_page(hide_sidebar_for_participant=True)
 
 
 SCROLL_RESET_FLAG_KEY = "experiment1_scroll_reset_done"
+ACTIVE_PAGE_STATE_KEY = "current_active_page"
+ACTIVE_PAGE_VALUE = "experiment_1"
 
 
 def _scroll_to_top_on_first_load() -> None:
-    if st.session_state.get(SCROLL_RESET_FLAG_KEY):
-        return
-    components.html(
-        """
-        <script>
-        const doc = window.parent ? window.parent.document : document;
-        const main = doc ? doc.querySelector('section.main') : null;
-        if (main) {
-            main.scrollTo(0, 0);
-        } else {
-            window.scrollTo(0, 0);
-        }
-        </script>
-        """,
-        height=0,
-    )
-    st.session_state[SCROLL_RESET_FLAG_KEY] = True
+    if st.session_state.get(ACTIVE_PAGE_STATE_KEY) != ACTIVE_PAGE_VALUE:
+        st.session_state.pop(SCROLL_RESET_FLAG_KEY, None)
+
+    if not st.session_state.get(SCROLL_RESET_FLAG_KEY):
+        components.html(
+            """
+            <script>
+            const doc = window.parent ? window.parent.document : document;
+            const main = doc ? doc.querySelector('section.main') : null;
+            if (main) {
+                main.scrollTo(0, 0);
+            } else {
+                window.scrollTo(0, 0);
+            }
+            </script>
+            """,
+            height=0,
+        )
+        st.session_state[SCROLL_RESET_FLAG_KEY] = True
+
+    st.session_state[ACTIVE_PAGE_STATE_KEY] = ACTIVE_PAGE_VALUE
 
 def _reset_conversation_state(system_prompt: str) -> None:
     """Reset conversation-related session state for experiment 1."""

--- a/pages/experiment_2.py
+++ b/pages/experiment_2.py
@@ -39,26 +39,32 @@ configure_page(hide_sidebar_for_participant=True)
 
 
 SCROLL_RESET_FLAG_KEY = "experiment2_scroll_reset_done"
+ACTIVE_PAGE_STATE_KEY = "current_active_page"
+ACTIVE_PAGE_VALUE = "experiment_2"
 
 
 def _scroll_to_top_on_first_load() -> None:
-    if st.session_state.get(SCROLL_RESET_FLAG_KEY):
-        return
-    components.html(
-        """
-        <script>
-        const doc = window.parent ? window.parent.document : document;
-        const main = doc ? doc.querySelector('section.main') : null;
-        if (main) {
-            main.scrollTo(0, 0);
-        } else {
-            window.scrollTo(0, 0);
-        }
-        </script>
-        """,
-        height=0,
-    )
-    st.session_state[SCROLL_RESET_FLAG_KEY] = True
+    if st.session_state.get(ACTIVE_PAGE_STATE_KEY) != ACTIVE_PAGE_VALUE:
+        st.session_state.pop(SCROLL_RESET_FLAG_KEY, None)
+
+    if not st.session_state.get(SCROLL_RESET_FLAG_KEY):
+        components.html(
+            """
+            <script>
+            const doc = window.parent ? window.parent.document : document;
+            const main = doc ? doc.querySelector('section.main') : null;
+            if (main) {
+                main.scrollTo(0, 0);
+            } else {
+                window.scrollTo(0, 0);
+            }
+            </script>
+            """,
+            height=0,
+        )
+        st.session_state[SCROLL_RESET_FLAG_KEY] = True
+
+    st.session_state[ACTIVE_PAGE_STATE_KEY] = ACTIVE_PAGE_VALUE
 
 def _reset_conversation_state(system_prompt: str) -> None:
     """Reset conversation-related session state for experiment 1."""

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,8 +2,12 @@ import streamlit as st
 
 from consent import require_consent
 
+ACTIVE_PAGE_STATE_KEY = "current_active_page"
+ACTIVE_PAGE_VALUE = "instructions"
+
 def app():
     require_consent(allow_withdrawal=True, redirect_to_instructions=False)
+    st.session_state[ACTIVE_PAGE_STATE_KEY] = ACTIVE_PAGE_VALUE
     if st.session_state.get("redirect_to_instruction_page"):
         st.session_state["redirect_to_instruction_page"] = False
     st.title("LLMATCH Criticデモアプリ")


### PR DESCRIPTION
## Summary
- track the current active page in session state so we can detect page transitions
- rerun the scroll-to-top script whenever the user navigates to Experiment 1 or Experiment 2
- register the instructions page as the active page when it loads so experiment pages scroll properly on return

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df96934c0883208aba5a57dac76abd